### PR TITLE
Save proposals sort order to URL

### DIFF
--- a/src/firebase/proposals.js
+++ b/src/firebase/proposals.js
@@ -17,9 +17,9 @@ export const fetchProposal = (eventId, proposalId) =>
 /**
  * Fetch all proposals of an event
  * @param {string} eventId event id
- * @param {object} options options with filters and sorting
+ * @param {object} options options with filters and sortOrder
  */
-export const fetchEventProposals = async (eventId, uid, { categories, formats, sorting } = {}) => {
+export const fetchEventProposals = async (eventId, uid, { categories, formats, sortOrder } = {}) => {
   let query = firebase
     .firestore()
     .collection('events')
@@ -33,15 +33,15 @@ export const fetchEventProposals = async (eventId, uid, { categories, formats, s
   if (formats) {
     query = query.where('formats', '==', formats)
   }
-  // add sorting
-  if (sorting) {
-    if (sorting === 'newest') {
+  // add sortOrder
+  if (sortOrder) {
+    if (sortOrder === 'newest') {
       query = query.orderBy('updateTimestamp', 'desc')
-    } else if (sorting === 'oldest') {
+    } else if (sortOrder === 'oldest') {
       query = query.orderBy('updateTimestamp', 'asc')
-    } else if (sorting === 'highestRating') {
+    } else if (sortOrder === 'highestRating') {
       query = query.orderBy('rating', 'desc')
-    } else if (sorting === 'lowestRating') {
+    } else if (sortOrder === 'lowestRating') {
       query = query.orderBy('rating', 'asc')
     }
   }

--- a/src/screens/organizer/proposals/proposalFilters/proposalFilters.container.js
+++ b/src/screens/organizer/proposals/proposalFilters/proposalFilters.container.js
@@ -5,13 +5,13 @@ import ProposalFilters from './proposalFilters'
 
 const mapStore = (store) => {
   const eventId = getRouterParam('eventId')(store.getState())
-  const { sortings } = getRouterResult(store.getState())
+  const { sortOrders } = getRouterResult(store.getState())
   const filters = store.ui.organizer.proposals.get()
   const { formats, categories } = store.data.events.get(eventId) || {}
   return {
     formats,
     categories,
-    sortings,
+    sortOrders,
     filters,
     onChange: ({ target }) => {
       store.ui.organizer.proposals.update({ [target.id]: target.value })

--- a/src/screens/organizer/proposals/proposalFilters/proposalFilters.container.js
+++ b/src/screens/organizer/proposals/proposalFilters/proposalFilters.container.js
@@ -1,15 +1,17 @@
 import { inject } from '@k-ramel/react'
 
-import { getRouterParam } from 'store/reducers/router'
+import { getRouterParam, getRouterResult } from 'store/reducers/router'
 import ProposalFilters from './proposalFilters'
 
 const mapStore = (store) => {
   const eventId = getRouterParam('eventId')(store.getState())
+  const { sortings } = getRouterResult(store.getState())
   const filters = store.ui.organizer.proposals.get()
   const { formats, categories } = store.data.events.get(eventId) || {}
   return {
     formats,
     categories,
+    sortings,
     filters,
     onChange: ({ target }) => {
       store.ui.organizer.proposals.update({ [target.id]: target.value })

--- a/src/screens/organizer/proposals/proposalFilters/proposalFilters.jsx
+++ b/src/screens/organizer/proposals/proposalFilters/proposalFilters.jsx
@@ -3,9 +3,15 @@ import PropTypes from 'prop-types'
 
 import './proposalFilters.css'
 
-const ProposalFilters = ({
-  formats, categories, filters, onChange,
-}) => (
+const sortingLabel = sorting =>
+  ({
+    newest: 'Newest',
+    oldest: 'Oldest',
+    highestRating: 'Highest Ratings',
+    lowestRating: 'Lowest Ratings',
+  }[sorting])
+
+const ProposalFilters = ({ formats, categories, sortings, filters, onChange }) => (
   <div className="proposals-filters">
     <select id="formats" onChange={onChange} defaultValue={filters.formats}>
       <option value="">All formats</option>
@@ -27,10 +33,11 @@ const ProposalFilters = ({
 
     <select id="sorting" onChange={onChange} defaultValue={filters.sorting}>
       <option value="">Sort</option>
-      <option value="newest">Newest</option>
-      <option value="oldest">Oldest</option>
-      <option value="highestRating">Highest ratings</option>
-      <option value="lowestRating">Lowest ratings</option>
+      {sortings.map(sorting => (
+        <option key={sorting} value={sorting}>
+          {sortingLabel(sorting)}
+        </option>
+      ))}
     </select>
   </div>
 )
@@ -38,6 +45,7 @@ const ProposalFilters = ({
 ProposalFilters.propTypes = {
   formats: PropTypes.arrayOf(PropTypes.object),
   categories: PropTypes.arrayOf(PropTypes.object),
+  sortings: PropTypes.arrayOf(PropTypes.string),
   filters: PropTypes.objectOf(PropTypes.string),
   onChange: PropTypes.func.isRequired,
 }
@@ -45,6 +53,7 @@ ProposalFilters.propTypes = {
 ProposalFilters.defaultProps = {
   formats: [],
   categories: [],
+  sortings: [],
   filters: {},
 }
 

--- a/src/screens/organizer/proposals/proposalFilters/proposalFilters.jsx
+++ b/src/screens/organizer/proposals/proposalFilters/proposalFilters.jsx
@@ -3,15 +3,15 @@ import PropTypes from 'prop-types'
 
 import './proposalFilters.css'
 
-const sortingLabel = sorting =>
+const sortOrderLabel = sortOrder =>
   ({
     newest: 'Newest',
     oldest: 'Oldest',
     highestRating: 'Highest Ratings',
     lowestRating: 'Lowest Ratings',
-  }[sorting])
+  }[sortOrder])
 
-const ProposalFilters = ({ formats, categories, sortings, filters, onChange }) => (
+const ProposalFilters = ({ formats, categories, sortOrders, filters, onChange }) => (
   <div className="proposals-filters">
     <select id="formats" onChange={onChange} defaultValue={filters.formats}>
       <option value="">All formats</option>
@@ -31,11 +31,11 @@ const ProposalFilters = ({ formats, categories, sortings, filters, onChange }) =
       ))}
     </select>
 
-    <select id="sorting" onChange={onChange} defaultValue={filters.sorting}>
+    <select id="sortOrder" onChange={onChange} defaultValue={filters.sortOrder}>
       <option value="">Sort</option>
-      {sortings.map(sorting => (
-        <option key={sorting} value={sorting}>
-          {sortingLabel(sorting)}
+      {sortOrders.map(sortOrder => (
+        <option key={sortOrder} value={sortOrder}>
+          {sortOrderLabel(sortOrder)}
         </option>
       ))}
     </select>
@@ -45,7 +45,7 @@ const ProposalFilters = ({ formats, categories, sortings, filters, onChange }) =
 ProposalFilters.propTypes = {
   formats: PropTypes.arrayOf(PropTypes.object),
   categories: PropTypes.arrayOf(PropTypes.object),
-  sortings: PropTypes.arrayOf(PropTypes.string),
+  sortOrders: PropTypes.arrayOf(PropTypes.string),
   filters: PropTypes.objectOf(PropTypes.string),
   onChange: PropTypes.func.isRequired,
 }
@@ -53,7 +53,7 @@ ProposalFilters.propTypes = {
 ProposalFilters.defaultProps = {
   formats: [],
   categories: [],
-  sortings: [],
+  sortOrders: [],
   filters: {},
 }
 

--- a/src/store/listeners/listeners.js
+++ b/src/store/listeners/listeners.js
@@ -52,7 +52,7 @@ export default [
   when('@@ui/ON_SELECT_PROPOSAL')(proposals.selectProposal),
   when('@@ui/ON_NEXT_PROPOSAL')(proposals.nextProposal),
   when('@@ui/ON_PREVIOUS_PROPOSAL')(proposals.previousProposal),
-  when('@@krf/UPDATE>UI_ORGANIZER>PROPOSALS')(proposals.savesortOrderToRoute),
+  when('@@krf/UPDATE>UI_ORGANIZER>PROPOSALS')(proposals.saveSortOrderToRoute),
   /* ratings */
   when('@@ui/ON_LOAD_RATINGS')(ratings.fetchRatings),
   when('@@ui/RATE_PROPOSAL')(ratings.rateProposal),

--- a/src/store/listeners/listeners.js
+++ b/src/store/listeners/listeners.js
@@ -52,7 +52,7 @@ export default [
   when('@@ui/ON_SELECT_PROPOSAL')(proposals.selectProposal),
   when('@@ui/ON_NEXT_PROPOSAL')(proposals.nextProposal),
   when('@@ui/ON_PREVIOUS_PROPOSAL')(proposals.previousProposal),
-  when('@@krf/UPDATE>UI_ORGANIZER>PROPOSALS')(proposals.saveSortingToRoute),
+  when('@@krf/UPDATE>UI_ORGANIZER>PROPOSALS')(proposals.savesortOrderToRoute),
   /* ratings */
   when('@@ui/ON_LOAD_RATINGS')(ratings.fetchRatings),
   when('@@ui/RATE_PROPOSAL')(ratings.rateProposal),

--- a/src/store/listeners/listeners.js
+++ b/src/store/listeners/listeners.js
@@ -52,6 +52,7 @@ export default [
   when('@@ui/ON_SELECT_PROPOSAL')(proposals.selectProposal),
   when('@@ui/ON_NEXT_PROPOSAL')(proposals.nextProposal),
   when('@@ui/ON_PREVIOUS_PROPOSAL')(proposals.previousProposal),
+  when('@@krf/UPDATE>UI_ORGANIZER>PROPOSALS')(proposals.saveSortingToRoute),
   /* ratings */
   when('@@ui/ON_LOAD_RATINGS')(ratings.fetchRatings),
   when('@@ui/RATE_PROPOSAL')(ratings.rateProposal),

--- a/src/store/listeners/reactions/proposals.js
+++ b/src/store/listeners/reactions/proposals.js
@@ -70,7 +70,7 @@ export const previousProposal = reaction(async (action, store) => {
   }
 })
 
-export const savesortOrderToRoute = reaction(async (action, store) => {
+export const saveSortOrderToRoute = reaction(async (action, store) => {
   const { sortOrder } = action.payload
   if (!sortOrder) return
   const query = getRouterQuery(store.getState())

--- a/src/store/listeners/reactions/proposals.js
+++ b/src/store/listeners/reactions/proposals.js
@@ -1,7 +1,7 @@
 import { reaction } from 'k-ramel'
-import { push } from 'redux-little-router'
+import { push, replace } from 'redux-little-router'
 
-import { getRouterParam } from 'store/reducers/router'
+import { getRouterParam, getRouterQuery } from 'store/reducers/router'
 import { fetchProposal, fetchEventProposals } from 'firebase/proposals'
 
 export const loadEventProposals = reaction(async (action, store) => {
@@ -68,4 +68,12 @@ export const previousProposal = reaction(async (action, store) => {
     store.dispatch({ type: '@@ui/ON_LOAD_RATINGS', payload: { eventId, proposalId } })
     store.dispatch(push(`/organizer/event/${eventId}/proposal/${proposalId}`))
   }
+})
+
+export const saveSortingToRoute = reaction(async (action, store) => {
+  const { sorting } = action.payload
+  if (!sorting) return
+  const query = getRouterQuery(store.getState())
+  if (sorting === query.sorting) return
+  store.dispatch(replace({ query: { ...query, sorting } }))
 })

--- a/src/store/listeners/reactions/proposals.js
+++ b/src/store/listeners/reactions/proposals.js
@@ -70,10 +70,10 @@ export const previousProposal = reaction(async (action, store) => {
   }
 })
 
-export const saveSortingToRoute = reaction(async (action, store) => {
-  const { sorting } = action.payload
-  if (!sorting) return
+export const savesortOrderToRoute = reaction(async (action, store) => {
+  const { sortOrder } = action.payload
+  if (!sortOrder) return
   const query = getRouterQuery(store.getState())
-  if (sorting === query.sorting) return
-  store.dispatch(replace({ query: { ...query, sorting } }))
+  if (sortOrder === query.sortOrder) return
+  store.dispatch(replace({ query: { ...query, sortOrder } }))
 })

--- a/src/store/listeners/reactions/router.js
+++ b/src/store/listeners/reactions/router.js
@@ -2,6 +2,7 @@ import { reaction } from 'k-ramel'
 import { initializeCurrentLocation } from 'redux-little-router'
 
 import { isRoute, isSpeakerRoute, getRouterParam } from 'store/reducers/router'
+import { getRouterQueryParam } from '../../reducers/router/index'
 
 export const init = reaction((action, store) => {
   const initialLocation = store.getState().router
@@ -37,5 +38,11 @@ export const onRouteChanged = reaction((action, store) => {
     const uid = getRouterParam('uid')(state)
     store.dispatch({ type: '@@ui/ON_LOAD_TALK', payload: talkId })
     store.dispatch({ type: '@@ui/FETCH_USER', payload: uid })
+  }
+
+  // when Proposal route, restore sorting from route query
+  if (isRoute('PROPOSALS')(state)) {
+    const sorting = getRouterQueryParam('sorting')(state)
+    store.dispatch(store.ui.organizer.proposals.update({ sorting }))
   }
 })

--- a/src/store/listeners/reactions/router.js
+++ b/src/store/listeners/reactions/router.js
@@ -63,13 +63,13 @@ export const onRouteChanged = reaction((action, store) => {
         newValue: validValues[0],
       }
     }
-    const availablesortOrders = getRouterResult(store.getState()).sortOrders
+    const availableSortOrders = getRouterResult(store.getState()).sortOrders
     const sortOrderFromRouterState = getRouterQuery(store.getState()).sortOrder
     const sortOrderFromAppState = store.ui.organizer.proposals.get().sortOrder
     const { shouldUpdateAppState, shouldUpdateRouterState, newValue: sortOrder } = reconcile(
       sortOrderFromAppState,
       sortOrderFromRouterState,
-      availablesortOrders,
+      availableSortOrders,
     )
     if (shouldUpdateAppState) {
       store.dispatch(store.ui.organizer.proposals.update({ sortOrder }))

--- a/src/store/listeners/reactions/router.js
+++ b/src/store/listeners/reactions/router.js
@@ -72,7 +72,7 @@ export const onRouteChanged = reaction((action, store) => {
       availableSortOrders,
     )
     if (shouldUpdateAppState) {
-      store.dispatch(store.ui.organizer.proposals.update({ sortOrder }))
+      store.ui.organizer.proposals.update({ sortOrder })
     }
     if (shouldUpdateRouterState) {
       const query = getRouterQuery(store.getState())

--- a/src/store/listeners/reactions/router.js
+++ b/src/store/listeners/reactions/router.js
@@ -45,7 +45,7 @@ export const onRouteChanged = reaction((action, store) => {
     store.dispatch({ type: '@@ui/FETCH_USER', payload: uid })
   }
 
-  // when Proposal route, restore sorting from route query
+  // when Proposal route, restore sortOrder from route query
   // (or the other way around as a fallback)
   if (isRoute('PROPOSALS')(state)) {
     const reconcile = (appState, routerState, validValues) => {
@@ -63,20 +63,20 @@ export const onRouteChanged = reaction((action, store) => {
         newValue: validValues[0],
       }
     }
-    const availableSortings = getRouterResult(store.getState()).sortings
-    const sortingFromRouterState = getRouterQuery(store.getState()).sorting
-    const sortingFromAppState = store.ui.organizer.proposals.get().sorting
-    const { shouldUpdateAppState, shouldUpdateRouterState, newValue: sorting } = reconcile(
-      sortingFromAppState,
-      sortingFromRouterState,
-      availableSortings,
+    const availablesortOrders = getRouterResult(store.getState()).sortOrders
+    const sortOrderFromRouterState = getRouterQuery(store.getState()).sortOrder
+    const sortOrderFromAppState = store.ui.organizer.proposals.get().sortOrder
+    const { shouldUpdateAppState, shouldUpdateRouterState, newValue: sortOrder } = reconcile(
+      sortOrderFromAppState,
+      sortOrderFromRouterState,
+      availablesortOrders,
     )
     if (shouldUpdateAppState) {
-      store.dispatch(store.ui.organizer.proposals.update({ sorting }))
+      store.dispatch(store.ui.organizer.proposals.update({ sortOrder }))
     }
     if (shouldUpdateRouterState) {
       const query = getRouterQuery(store.getState())
-      store.dispatch(replace({ query: { ...query, sorting } }))
+      store.dispatch(replace({ query: { ...query, sortOrder } }))
     }
   }
 })

--- a/src/store/listeners/reactions/router.js
+++ b/src/store/listeners/reactions/router.js
@@ -1,8 +1,8 @@
 import { reaction } from 'k-ramel'
-import { initializeCurrentLocation } from 'redux-little-router'
+import { initializeCurrentLocation, replace } from 'redux-little-router'
 
 import { isRoute, isSpeakerRoute, getRouterParam } from 'store/reducers/router'
-import { getRouterQueryParam } from '../../reducers/router/index'
+import { getRouterQuery } from '../../reducers/router/index'
 
 export const init = reaction((action, store) => {
   const initialLocation = store.getState().router
@@ -41,8 +41,15 @@ export const onRouteChanged = reaction((action, store) => {
   }
 
   // when Proposal route, restore sorting from route query
+  // (or the other way around as a fallback)
   if (isRoute('PROPOSALS')(state)) {
-    const sorting = getRouterQueryParam('sorting')(state)
-    store.dispatch(store.ui.organizer.proposals.update({ sorting }))
+    const query = getRouterQuery(store.getState())
+    if (query.sorting) {
+      store.dispatch(store.ui.organizer.proposals.update({ sorting: query.sorting }))
+    } else {
+      const { sorting } = store.ui.organizer.proposals.get(state)
+      if (!sorting) return
+      store.dispatch(replace({ query: { ...query, sorting } }))
+    }
   }
 })

--- a/src/store/reducers/router/router.selectors.js
+++ b/src/store/reducers/router/router.selectors.js
@@ -3,6 +3,8 @@ export const getRouter = state => state.router
 export const getRouterResult = state => getRouter(state).result
 export const getRouterParams = state => getRouter(state).params
 export const getRouterParam = key => state => getRouterParams(state)[key]
+export const getRouterQuery = state => getRouter(state).query
+export const getRouterQueryParam = key => state => getRouterQuery(state)[key]
 
 // get the given attribute value for the current route hierarchy
 const getRecursively = (result, attribute) => {

--- a/src/store/reducers/router/routes.js
+++ b/src/store/reducers/router/routes.js
@@ -26,7 +26,7 @@ export default {
         },
         '/proposals': {
           title: 'PROPOSALS',
-          sortings: ['newest', 'oldest', 'highestRating', 'lowestRating'],
+          sortOrders: ['newest', 'oldest', 'highestRating', 'lowestRating'],
         },
         '/proposal/:proposalId': { title: 'PROPOSAL' },
       },

--- a/src/store/reducers/router/routes.js
+++ b/src/store/reducers/router/routes.js
@@ -24,7 +24,10 @@ export default {
           '/cfp': { title: 'EDIT_EVENT_CFP' },
           '/members': { title: 'EDIT_EVENT_MEMBERS' },
         },
-        '/proposals': { title: 'PROPOSALS' },
+        '/proposals': {
+          title: 'PROPOSALS',
+          sortings: ['newest', 'oldest', 'highestRating', 'lowestRating'],
+        },
         '/proposal/:proposalId': { title: 'PROPOSAL' },
       },
     },

--- a/src/store/reducers/ui/organizer/proposals.js
+++ b/src/store/reducers/ui/organizer/proposals.js
@@ -3,7 +3,7 @@ import { simpleObject } from 'k-ramel'
 const defaultData = {
   categories: '',
   formats: '',
-  sorting: 'newest',
+  sortOrder: 'newest',
 }
 
 export default simpleObject({ defaultData })


### PR DESCRIPTION
# Behavior before this change

- As an organiser, select an event, then go to "Call for paper" page
- Proposals are listed newest first
- I change the sort order to Highest rating
- I refresh the page
- Proposals are listed newest first

# Behavior after this change

- I change the sort order to Highest rating
- I refresh the page
- Proposals are listed highest rating first

# Detailed behavior

Changing the sort order in the UI updates the route query parameter `sortOrder` to match.

When landing on the `PROPOSALS` route, since there might be a sort order stored in both the router state and the UI state, the app need to reconcile the 2 values. Here's the algorithm that I used:
- Landing without a query parameter `sortOrder` updates the route to the order set in the UI state, unless there is none, in which case the order default to `newest`.
- Landing with a valid* query parameter `sortOrder` updates the UI state to match
- Landing with an invalid* query parameter `sortOrder` results in both the route query parameter and the UI state getting set to `newest`

\* "valid" refers to the value being one of the four values defined in the route config for the route `PROPOSALS`

Summing it up in a table:

Router / UI | No sort order | Has sort order `ui`
----|----|----
No sort order | `newest` | `ui`
Has sort order `router` | `router` | `router`
Has invalid sort order | `newest` | `newest`