### PR TITLE
✨ send email when deliberation set the talk to accepted or rejected

### DIFF
--- a/functions/email/templates/talkAccepted.js
+++ b/functions/email/templates/talkAccepted.js
@@ -1,0 +1,25 @@
+module.exports = (event, users, talk, url) => `
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+  <title>✨Your talk has been accepted✨</title>
+  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+  <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0 " />
+</head>
+<body>
+  <p>Dear ${users.map(user => user.displayName)},</p>
+  <p>Your talk <strong>"${talk.title}"</strong> has been accepted! 🎉  🎊</p>
+  <p>In order to help organizers for the selection and the event management, please confirm your venue:<p>
+  <ul>
+  <li><strong><a href="${url}/speaker/talk/${talk.id}">My talk <strong>${talk.title}<strong></a></li></strong>
+  </p>
+  <p>
+  Thanks !
+  </p>
+  <p>
+  See you there – <i>"${event.name}" team</i>
+  </p>
+  </body>
+</html>
+`

--- a/functions/email/templates/talkAccepted.js
+++ b/functions/email/templates/talkAccepted.js
@@ -8,7 +8,7 @@ module.exports = (event, users, talk, url) => `
   <meta name="viewport" content="width=device-width, initial-scale=1.0 " />
 </head>
 <body>
-  <p>Dear ${users.map(user => user.displayName)},</p>
+  <p>Dear ${users.map(user => user.displayName).join(', ')}</p>
   <p>Your talk <strong>"${talk.title}"</strong> has been accepted! 🎉  🎊</p>
   <p>In order to help organizers for the selection and the event management, please confirm your venue:<p>
   <ul>

--- a/functions/email/templates/talkRejected.js
+++ b/functions/email/templates/talkRejected.js
@@ -8,7 +8,7 @@ module.exports = (event, users, talk, url) => `
   <meta name="viewport" content="width=device-width, initial-scale=1.0 " />
 </head>
 <body>
-  <p>Dear ${users.map(user => user.displayName)},</p>
+  <p>Dear <p>Dear ${users.map(user => user.displayName).join(', ')}</p></p>
   <p>Your talk <strong>"${talk.title}"</strong> has been declined!</p>
   <p>
   We had lots of excellent talks this year and choosing has been heart-breaking 😓 

--- a/functions/email/templates/talkRejected.js
+++ b/functions/email/templates/talkRejected.js
@@ -1,0 +1,22 @@
+module.exports = (event, users, talk, url) => `
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+  <title>Your talk has been declined</title>
+  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+  <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0 " />
+</head>
+<body>
+  <p>Dear ${users.map(user => user.displayName)},</p>
+  <p>Your talk <strong>"${talk.title}"</strong> has been declined!</p>
+  <p>
+  We had lots of excellent talks this year and choosing has been heart-breaking 😓 
+  Thank you very for your submission and please consider resubmitting next year.
+  </p>
+  <p>
+  With love – <i>"${event.name}" team</i>
+  </p>
+  </body>
+</html>
+`

--- a/functions/index.js
+++ b/functions/index.js
@@ -4,6 +4,7 @@ initialize()
 
 // functions for triggered events calls
 exports.onCreateProposal = require('./triggers/onCreateProposal')
+exports.onUpdateProposal = require('./triggers/onUpdateProposal')
 
 // functions for HTTP APIs
 exports.api = require('./api')

--- a/functions/triggers/onCreateProposal.js
+++ b/functions/triggers/onCreateProposal.js
@@ -7,7 +7,9 @@ const talkConfirmed = require('../email/templates/talkConfirmed')
 module.exports = functions.firestore
   .document('events/{eventId}/proposals/{proposalId}')
   .onCreate((snap, context) => {
+    console.log(':::create::snap' + JSON.stringify(snap))
     const talk = snap.data()
+    console.log(':::create::talk' + JSON.stringify(talk))
     const { eventId } = context.params
     const uids = Object.keys(talk.speakers)
 

--- a/functions/triggers/onUpdateProposal.js
+++ b/functions/triggers/onUpdateProposal.js
@@ -1,0 +1,50 @@
+const functions = require('firebase-functions')
+const { getEvent } = require('../firestore/event')
+const { getUsers } = require('../firestore/user')
+const { updateProposal } = require('../firestore/proposal')
+const sendEmail = require('../email')
+const talkAccepted = require('../email/templates/talkAccepted')
+const talkRejected = require('../email/templates/talkRejected')
+
+module.exports = functions.firestore
+  .document('events/{eventId}/proposals/{proposalId}')
+  .onUpdate((snap, context) => {
+    const talk = snap.after.data()
+    console.log(`:::update::talk ${JSON.stringify(talk)}`)
+
+    const { eventId } = context.params
+    const uids = Object.keys(talk.speakers)
+    const accepted = talk.state === 'accepted'
+    const rejected = talk.state === 'rejected'
+    const { app, mailgun } = functions.config()
+    if (!app) return Promise.reject(new Error('You must provide the app.url variable'))
+
+    if (accepted && talk.emailSent === undefined) {
+      console.log(`:::update::accepted & set emailSent to talk ${talk.title}`)
+      // set emailSent to make sure we send accepted email only once.
+      talk.emailSent = talk.updateTimestamp
+      return Promise.all([
+        getEvent(eventId),
+        getUsers(uids),
+        updateProposal(eventId, talk)]).then(([event, users]) => sendEmail(mailgun, {
+        to: users.map(user => user.email),
+        subject: `[${event.name}] Talk accepted!`,
+        html: talkAccepted(event, users, talk, app.url),
+      }))
+    }
+
+    if (rejected && talk.emailSent === undefined) {
+      console.log(`:::update::rejected & set emailSent to talk ${talk.title}`)
+      // set emailSent to make sure we send declined email only once.
+      talk.emailSent = talk.updateTimestamp
+      return Promise.all([
+        getEvent(eventId),
+        getUsers(uids),
+        updateProposal(eventId, talk)]).then(([event, users]) => sendEmail(mailgun, {
+        to: users.map(user => user.email),
+        subject: `[${event.name}] Talk declined`,
+        html: talkRejected(event, users, talk, app.url),
+      }))
+    }
+    return null
+  })

--- a/functions/triggers/onUpdateProposal.js
+++ b/functions/triggers/onUpdateProposal.js
@@ -27,9 +27,9 @@ module.exports = functions.firestore
         getEvent(eventId),
         getUsers(uids),
         updateProposal(eventId, talk)]).then(([event, users]) => sendEmail(mailgun, {
-        to: users.map(user => user.email),
-        subject: `[${event.name}] Talk accepted!`,
-        html: talkAccepted(event, users, talk, app.url),
+          to: users.map(user => user.email),
+          subject: `[${event.name}] Talk accepted!`,
+          html: talkAccepted(event, users, talk, app.url),
       }))
     }
 
@@ -41,9 +41,9 @@ module.exports = functions.firestore
         getEvent(eventId),
         getUsers(uids),
         updateProposal(eventId, talk)]).then(([event, users]) => sendEmail(mailgun, {
-        to: users.map(user => user.email),
-        subject: `[${event.name}] Talk declined`,
-        html: talkRejected(event, users, talk, app.url),
+          to: users.map(user => user.email),
+          subject: `[${event.name}] Talk declined`,
+          html: talkRejected(event, users, talk, app.url),
       }))
     }
     return null

--- a/src/screens/organizer/components/talkSelection/talkSelection.jsx
+++ b/src/screens/organizer/components/talkSelection/talkSelection.jsx
@@ -49,7 +49,7 @@ const TalkSelection = ({ onChange, defaultValue }) => {
       )}
 
     </div>
-)
+  )
 }
 
 TalkSelection.propTypes = {

--- a/src/screens/organizer/components/talkSelection/talkSelection.jsx
+++ b/src/screens/organizer/components/talkSelection/talkSelection.jsx
@@ -1,27 +1,56 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 
-const TalkSelection = ({ onChange, defaultValue }) => (
-  <select
-    id="ratings"
-    onChange={onChange}
-    onClick={e => e.stopPropagation()}
-    defaultValue={defaultValue}
-  >
-    <option key="submitted" value="submitted">
-      Deliberate...
-    </option>
-    <option key="accepted" value="accepted">
-      Accepted
-    </option>
-    <option key="backup" value="backup">
-      Backup
-    </option>
-    <option key="rejected" value="rejected">
-      Rejected
-    </option>
-  </select>
+const TalkSelection = ({ onChange, defaultValue }) => {
+  const talkDeliberation = defaultValue
+  return (
+    <div>
+      {talkDeliberation === 'accepted' || talkDeliberation === 'rejected' ? (
+        <select
+          id="ratings"
+          onChange={onChange}
+          onClick={e => e.stopPropagation()}
+          defaultValue={defaultValue}
+          disabled
+        >
+          <option key="submitted" value="submitted">
+            Deliberate...
+          </option>
+          <option key="accepted" value="accepted">
+            Accepted
+          </option>
+          <option key="backup" value="backup">
+            Backup
+          </option>
+          <option key="rejected" value="rejected">
+            Rejected
+          </option>
+        </select>
+      ) : (
+        <select
+          id="ratings"
+          onChange={onChange}
+          onClick={e => e.stopPropagation()}
+          defaultValue={defaultValue}
+        >
+          <option key="submitted" value="submitted">
+            Deliberate...
+          </option>
+          <option key="accepted" value="accepted">
+            Accepted
+          </option>
+          <option key="backup" value="backup">
+            Backup
+          </option>
+          <option key="rejected" value="rejected">
+            Rejected
+          </option>
+        </select>
+      )}
+
+    </div>
 )
+}
 
 TalkSelection.propTypes = {
   onChange: PropTypes.func.isRequired,


### PR DESCRIPTION
Related to https://github.com/bpetetot/conference-hall/issues/250
This PR is a proposal to cover the need to send an email for accepted and rejected proposal. The email should be sent only once.

Some topics to discuss:
- maybe we can improve by making the dropdown for the deliberation become readonly once the email was sent.
- is there a way for a speaker to confirm his venue with the application. Fro ex: in the accepted email, I propose a link to the talk. It would be nice to have a confirm button and a new state for the talk "confirmed"
