### PR TITLE
✨add paging to proposals list

### DIFF
--- a/src/components/inline/inline.jsx
+++ b/src/components/inline/inline.jsx
@@ -1,13 +1,14 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import cn from 'classnames'
+import isEmpty from 'lodash/isEmpty'
 
 import './inline.css'
 
 class Inline extends React.Component {
   join = children => children.reduce((result, child, index) => {
     if (!child) return result
-    if (index === 0) return [...result, this.renderItem(child, index)]
+    if (index === 0 || isEmpty(result)) return [this.renderItem(child, index)]
     return [...result, this.renderSeparator(`${index}-separator`), this.renderItem(child, index)]
   }, [])
 

--- a/src/screens/organizer/proposals/proposalFilters/proposalFilters.jsx
+++ b/src/screens/organizer/proposals/proposalFilters/proposalFilters.jsx
@@ -1,5 +1,6 @@
-import React from 'react'
+import React, { Component } from 'react'
 import PropTypes from 'prop-types'
+import debounce from 'lodash/debounce'
 
 import './proposalFilters.css'
 
@@ -22,65 +23,89 @@ const statusLabel = status => ({
   rejected: 'Rejected',
 }[status])
 
-const ProposalFilters = ({
-  statuses,
-  ratings,
-  formats,
-  categories,
-  sortOrders,
-  filters,
-  onChange,
-  deliberationActive,
-}) => (
-  <div className="proposals-filters no-print">
-    {deliberationActive && (
-      <select id="state" onChange={onChange} defaultValue={filters.state}>
-        <option value="">All statuses</option>
-        {statuses.map(status => (
-          <option key={status} value={status}>
-            {statusLabel(status)}
-          </option>
-        ))}
-      </select>
-    )}
+class ProposalFilters extends Component {
+  constructor(props) {
+    super(props)
+    this.onChange = debounce(this.props.onChange, 200)
+  }
 
-    <select id="ratings" onChange={onChange} defaultValue={filters.ratings}>
-      <option value="">All ratings</option>
-      {ratings.map(rating => (
-        <option key={rating} value={rating}>
-          {ratingsLabel(rating)}
-        </option>
-      ))}
-    </select>
+  debounceOnChange = (e) => {
+    e.persist()
+    this.onChange(e)
+  }
 
-    <select id="formats" onChange={onChange} defaultValue={filters.formats}>
-      <option value="">All formats</option>
-      {formats.map(({ id, name }) => (
-        <option key={id} value={id}>
-          {name}
-        </option>
-      ))}
-    </select>
+  render() {
+    const {
+      statuses,
+      ratings,
+      formats,
+      categories,
+      sortOrders,
+      filters,
+      onChange,
+      deliberationActive,
+    } = this.props
 
-    <select id="categories" onChange={onChange} defaultValue={filters.categories}>
-      <option value="">All categories</option>
-      {categories.map(({ id, name }) => (
-        <option key={id} value={id}>
-          {name}
-        </option>
-      ))}
-    </select>
+    return (
+      <div className="proposals-filters no-print">
+        <input
+          id="search"
+          type="search"
+          placeholder="Search by proposal title"
+          onChange={this.debounceOnChange}
+          defaultValue={filters.search}
+        />
 
-    <select id="sortOrder" onChange={onChange} defaultValue={filters.sortOrder}>
-      <option value="">Sort</option>
-      {sortOrders.map(sortOrder => (
-        <option key={sortOrder} value={sortOrder}>
-          {sortOrderLabel(sortOrder)}
-        </option>
-      ))}
-    </select>
-  </div>
-)
+        {deliberationActive && (
+          <select id="state" onChange={onChange} defaultValue={filters.state}>
+            <option value="">All statuses</option>
+            {statuses.map(status => (
+              <option key={status} value={status}>
+                {statusLabel(status)}
+              </option>
+            ))}
+          </select>
+        )}
+
+        <select id="ratings" onChange={onChange} defaultValue={filters.ratings}>
+          <option value="">All ratings</option>
+          {ratings.map(rating => (
+            <option key={rating} value={rating}>
+              {ratingsLabel(rating)}
+            </option>
+          ))}
+        </select>
+
+        <select id="formats" onChange={onChange} defaultValue={filters.formats}>
+          <option value="">All formats</option>
+          {formats.map(({ id, name }) => (
+            <option key={id} value={id}>
+              {name}
+            </option>
+          ))}
+        </select>
+
+        <select id="categories" onChange={onChange} defaultValue={filters.categories}>
+          <option value="">All categories</option>
+          {categories.map(({ id, name }) => (
+            <option key={id} value={id}>
+              {name}
+            </option>
+          ))}
+        </select>
+
+        <select id="sortOrder" onChange={onChange} defaultValue={filters.sortOrder}>
+          <option value="">Sort</option>
+          {sortOrders.map(sortOrder => (
+            <option key={sortOrder} value={sortOrder}>
+              {sortOrderLabel(sortOrder)}
+            </option>
+          ))}
+        </select>
+      </div>
+    )
+  }
+}
 
 ProposalFilters.propTypes = {
   statuses: PropTypes.arrayOf(PropTypes.string),

--- a/src/screens/organizer/proposals/proposals.container.js
+++ b/src/screens/organizer/proposals/proposals.container.js
@@ -10,12 +10,10 @@ const mapStore = (store, props, { router }) => {
   const eventId = router.getRouteParam('eventId')
   const event = store.data.events.get(eventId)
   const nbProposals = store.data.proposals.getLength()
-  const route = router.getResultParam('title')
   return {
     loaded: !!event,
     nbProposals,
     eventId,
-    route,
     load: () => store.dispatch('@@ui/ON_LOAD_EVENT'),
   }
 }

--- a/src/screens/organizer/proposals/proposals.jsx
+++ b/src/screens/organizer/proposals/proposals.jsx
@@ -1,42 +1,25 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import { Link } from 'redux-little-router'
 
 import Titlebar from 'components/titlebar'
-import Button from 'components/button'
-import IconLabel from 'components/iconLabel'
 import ProposalFilters from './proposalFilters'
 import ProposalsList from './proposalsList'
-import ProposalsCards from './proposalsCards'
+import ProposalsPaging from './proposalsPaging'
 
-const Proposals = ({ eventId, nbProposals, route }) => {
+const Proposals = ({ eventId, nbProposals }) => {
   const title = nbProposals > 0 ? `Proposals (${nbProposals})` : 'Proposals'
   return (
     <div>
-      <Titlebar icon="fa fa-paper-plane" title={title} className="no-print">
-        <Button tertiary>
-          {btn => (route === 'PROPOSALS' ? (
-            <Link href={`/organizer/event/${eventId}/proposals/cards`} className={btn}>
-              <IconLabel icon="fa fa-th" label="Cards" />
-            </Link>
-          ) : (
-            <Link href={`/organizer/event/${eventId}/proposals`} className={btn}>
-              <IconLabel icon="fa fa-th-list" label="List" />
-            </Link>
-          ))
-          }
-        </Button>
-      </Titlebar>
+      <Titlebar icon="fa fa-paper-plane" title={title} className="no-print" />
       <ProposalFilters eventId={eventId} />
       <ProposalsList eventId={eventId} />
-      <ProposalsCards eventId={eventId} />
+      <ProposalsPaging />
     </div>
   )
 }
 
 Proposals.propTypes = {
   eventId: PropTypes.string.isRequired,
-  route: PropTypes.string.isRequired,
   nbProposals: PropTypes.number.isRequired,
 }
 

--- a/src/screens/organizer/proposals/proposals.reactions.js
+++ b/src/screens/organizer/proposals/proposals.reactions.js
@@ -9,7 +9,7 @@ export const setProposalFiltersFromRouter = (action, store, { router }) => {
   const { query } = router.get()
 
   const pickTruthyValues = pickBy(Boolean)
-  const pickFilterKeys = pick(['state', 'ratings', 'categories', 'formats', 'sortOrder'])
+  const pickFilterKeys = pick(['state', 'ratings', 'categories', 'formats', 'sortOrder', 'search'])
   const ensureIncludedIn = values => value => (values.includes(value) ? value : values[0])
 
   const filtersFromRouterState = pickFilterKeys(query)

--- a/src/screens/organizer/proposals/proposals.reactions.js
+++ b/src/screens/organizer/proposals/proposals.reactions.js
@@ -34,6 +34,7 @@ export const setProposalFiltersFromRouter = (action, store, { router }) => {
 /* load proposals */
 export const loadProposals = async (action, store, { router }) => {
   store.data.proposals.reset()
+  store.ui.organizer.proposalsPaging.update({ page: 1 })
 
   const eventId = router.getRouteParam('eventId')
   const { uid } = store.auth.get()

--- a/src/screens/organizer/proposals/proposalsCards/proposalsExport.container.js
+++ b/src/screens/organizer/proposals/proposalsCards/proposalsExport.container.js
@@ -5,14 +5,23 @@ import forRoute from 'hoc-little-router'
 import loader from 'components/loader'
 import ProposalsExport from './proposalsExport'
 
-const mapStore = store => ({
-  loaded: store.data.proposals.isInitialized(),
-  proposals: store.data.proposals.getAsArray(),
-  load: () => store.dispatch('@@ui/ON_LOAD_EVENT_PROPOSALS'),
-  onSelect: (eventId, proposalId) => {
-    store.dispatch({ type: '@@ui/ON_SELECT_PROPOSAL', payload: { eventId, proposalId } })
-  },
-})
+const mapStore = (store) => {
+  const { page, itemsPerPage } = store.ui.organizer.proposalsPaging.get()
+  const startIndex = (page - 1) * itemsPerPage
+  const endIndex = startIndex + itemsPerPage - 1
+  const proposals = store.data.proposals
+    .getAsArray()
+    .filter((_, index) => index >= startIndex && index <= endIndex)
+
+  return {
+    loaded: store.data.proposals.isInitialized(),
+    proposals,
+    load: () => store.dispatch('@@ui/ON_LOAD_EVENT_PROPOSALS'),
+    onSelect: (eventId, proposalId) => {
+      store.dispatch({ type: '@@ui/ON_SELECT_PROPOSAL', payload: { eventId, proposalId } })
+    },
+  }
+}
 
 export default compose(
   forRoute.absolute('PROPOSALS_CARDS'), //

--- a/src/screens/organizer/proposals/proposalsList/proposalSubtitle/proposalSubtitle.container.js
+++ b/src/screens/organizer/proposals/proposalsList/proposalSubtitle/proposalSubtitle.container.js
@@ -7,6 +7,7 @@ const mapStore = (store, { eventId, proposal }) => {
   const { formats, categories } = proposal
   const category = getCategory(eventId, categories)(store) || {}
   const format = getFormat(eventId, formats)(store) || {}
+
   return {
     categoryLabel: category.name,
     formatLabel: format.name,

--- a/src/screens/organizer/proposals/proposalsList/proposalSubtitle/proposalSubtitle.jsx
+++ b/src/screens/organizer/proposals/proposalsList/proposalSubtitle/proposalSubtitle.jsx
@@ -1,37 +1,23 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 
-import UserAvatar from 'screens/components/userAvatar'
 import Inline from 'components/inline'
 
 import './proposalSubtitle.css'
 
-const ProposalSubtitle = ({ proposal, formatLabel, categoryLabel }) => {
-  const { speakers = {} } = proposal
-  return (
-    <Inline className="proposal-subtitle" classNameItem="proposal-subtitle-item">
-      {Object.keys(speakers).map(id => (
-        <UserAvatar
-          key={id}
-          id={id}
-          className="proposal-item-info-speaker"
-          size="small"
-        />
-      ))}
-      {!!formatLabel && formatLabel}
-      {!!categoryLabel && categoryLabel}
-    </Inline>
-  )
-}
+const ProposalSubtitle = ({ formatLabel, categoryLabel }) => (
+  <Inline className="proposal-subtitle" classNameItem="proposal-subtitle-item">
+    {!!formatLabel && formatLabel}
+    {!!categoryLabel && categoryLabel}
+  </Inline>
+)
 
 ProposalSubtitle.propTypes = {
-  proposal: PropTypes.objectOf(PropTypes.any),
   formatLabel: PropTypes.string,
   categoryLabel: PropTypes.string,
 }
 
 ProposalSubtitle.defaultProps = {
-  proposal: {},
   formatLabel: undefined,
   categoryLabel: undefined,
 }

--- a/src/screens/organizer/proposals/proposalsList/proposalsList.container.js
+++ b/src/screens/organizer/proposals/proposalsList/proposalsList.container.js
@@ -5,14 +5,23 @@ import forRoute from 'hoc-little-router'
 import loader from 'components/loader'
 import ProposalsList from './proposalsList'
 
-const mapStore = store => ({
-  loaded: store.data.proposals.isInitialized(),
-  proposals: store.data.proposals.getAsArray(),
-  load: () => store.dispatch('@@ui/ON_LOAD_EVENT_PROPOSALS'),
-  onSelect: (eventId, proposalId) => {
-    store.dispatch({ type: '@@ui/ON_SELECT_PROPOSAL', payload: { eventId, proposalId } })
-  },
-})
+const mapStore = (store) => {
+  const { page, itemsPerPage } = store.ui.organizer.proposalsPaging.get()
+  const startIndex = (page - 1) * itemsPerPage
+  const endIndex = startIndex + itemsPerPage - 1
+  const proposals = store.data.proposals
+    .getAsArray()
+    .filter((_, index) => index >= startIndex && index <= endIndex)
+
+  return {
+    loaded: store.data.proposals.isInitialized(),
+    proposals,
+    load: () => store.dispatch('@@ui/ON_LOAD_EVENT_PROPOSALS'),
+    onSelect: (eventId, proposalId) => {
+      store.dispatch({ type: '@@ui/ON_SELECT_PROPOSAL', payload: { eventId, proposalId } })
+    },
+  }
+}
 
 export default compose(
   forRoute.absolute('PROPOSALS'), //

--- a/src/screens/organizer/proposals/proposalsPaging/index.js
+++ b/src/screens/organizer/proposals/proposalsPaging/index.js
@@ -1,0 +1,1 @@
+export { default } from './proposalsPaging.container'

--- a/src/screens/organizer/proposals/proposalsPaging/proposalsPaging.container.js
+++ b/src/screens/organizer/proposals/proposalsPaging/proposalsPaging.container.js
@@ -1,0 +1,19 @@
+import { inject } from '@k-ramel/react'
+
+import ProposalsPaging from './proposalsPaging'
+
+const mapStore = (store) => {
+  const { page, itemsPerPage } = store.ui.organizer.proposalsPaging.get()
+  const nbItems = store.data.proposals.getAsArray().length
+  const nbPage = Math.ceil(nbItems / itemsPerPage)
+
+  return {
+    loaded: store.data.proposals.isInitialized(),
+    nbItems,
+    page,
+    nbPage,
+    onPageChange: newPage => store.ui.organizer.proposalsPaging.update({ page: newPage }),
+  }
+}
+
+export default inject(mapStore)(ProposalsPaging)

--- a/src/screens/organizer/proposals/proposalsPaging/proposalsPaging.css
+++ b/src/screens/organizer/proposals/proposalsPaging/proposalsPaging.css
@@ -1,0 +1,27 @@
+.paging {
+  display: flex;
+  margin: 1em 0;
+}
+
+.paging-button {
+  padding: 10px;
+  background: #fff;
+  cursor: pointer;
+}
+
+.page-button-previous {
+  border-top-left-radius: 3px;
+  border-bottom-left-radius: 3px;
+  border-right-width: 0px;
+}
+
+.page-button-next {
+  border-top-right-radius: 3px;
+  border-bottom-right-radius: 3px;
+  border-left-width: 0px;
+}
+
+.paging .current-page {
+  color: var(--secondary-color);
+  font-weight: 700;
+}

--- a/src/screens/organizer/proposals/proposalsPaging/proposalsPaging.jsx
+++ b/src/screens/organizer/proposals/proposalsPaging/proposalsPaging.jsx
@@ -1,0 +1,59 @@
+import React, { Component } from 'react'
+import PropTypes from 'prop-types'
+
+import './proposalsPaging.css'
+
+class ProposalsPaging extends Component {
+  goToPage = page => () => {
+    this.props.onPageChange(page)
+  }
+
+  render() {
+    const {
+      loaded,
+      nbItems,
+      nbPage,
+      page,
+    } = this.props
+
+    if (!loaded || nbItems === 0) return null
+
+    return (
+      <div className="paging">
+        <button
+          type="button"
+          className="paging-button page-button-previous"
+          disabled={page <= 1}
+          onClick={this.goToPage(page - 1)}
+        >
+          Previous
+        </button>
+        <button
+          type="button"
+          className="paging-button"
+          disabled
+        >
+          {`${nbItems} proposals - page ${page}/${nbPage}`}
+        </button>
+        <button
+          type="button"
+          className="paging-button page-button-next"
+          disabled={page >= nbPage}
+          onClick={this.goToPage(page + 1)}
+        >
+          Next
+        </button>
+      </div>
+    )
+  }
+}
+
+ProposalsPaging.propTypes = {
+  loaded: PropTypes.bool.isRequired,
+  nbItems: PropTypes.number.isRequired,
+  page: PropTypes.number.isRequired,
+  nbPage: PropTypes.number.isRequired,
+  onPageChange: PropTypes.func.isRequired,
+}
+
+export default ProposalsPaging

--- a/src/screens/organizer/proposals/proposalsPaging/proposalsPaging.jsx
+++ b/src/screens/organizer/proposals/proposalsPaging/proposalsPaging.jsx
@@ -16,7 +16,7 @@ class ProposalsPaging extends Component {
       page,
     } = this.props
 
-    if (!loaded || nbItems === 0) return null
+    if (!loaded || nbPage <= 1) return null
 
     return (
       <div className="paging">

--- a/src/store/drivers/redux-little-router/routes.js
+++ b/src/store/drivers/redux-little-router/routes.js
@@ -34,9 +34,6 @@ export default {
           sortOrders: ['newest', 'oldest', 'highestRating', 'lowestRating'],
           ratings: ['rated', 'notRated'],
           statuses: ['submitted', 'accepted', 'backup', 'rejected'],
-          '/cards': {
-            title: 'PROPOSALS_CARDS',
-          },
         },
         '/proposal/:proposalId': { title: 'PROPOSAL' },
       },

--- a/src/store/reducers/ui/organizer/index.js
+++ b/src/store/reducers/ui/organizer/index.js
@@ -2,10 +2,12 @@ import myEvents from './myEvents'
 import myOrganizations from './myOrganizations'
 import proposal from './proposal'
 import proposals from './proposals'
+import proposalsPaging from './proposalsPaging'
 
 export default {
   myEvents,
   myOrganizations,
   proposal,
   proposals,
+  proposalsPaging,
 }

--- a/src/store/reducers/ui/organizer/proposalsPaging.js
+++ b/src/store/reducers/ui/organizer/proposalsPaging.js
@@ -1,0 +1,8 @@
+import { types } from 'k-ramel'
+
+const defaultData = {
+  page: 1,
+  itemsPerPage: 30,
+}
+
+export default types.object({ defaultData })


### PR DESCRIPTION
When there are lot of proposals, the proposals list performance is decreasing.

To improve performance of this page, some changes are needed:
- [x] add paging on proposals list
- [x] remove speaker names in the list (use too much bandwidth when massively requested)
- [x] add a search input on proposal titles (to be able to search in all pages)

Later (in an other PR), we will add a fulltext search feature on proposals and speakers. (see #38)