### PR TITLE
:lipstick: enlarge total rating zone

### DIFF
--- a/src/screens/organizer/components/totalRatings/rating.css
+++ b/src/screens/organizer/components/totalRatings/rating.css
@@ -2,7 +2,7 @@
   display: flex;
   flex-direction: column;
   align-items: flex-end;
-  min-width: 7em;
+  min-width: 8em;
   margin-right: 0.5em;
 }
 


### PR DESCRIPTION
This should fix #491 caused by a too tight slot for display all logos relating to the rating. 

I guess the min-width is important in order to keep all input aligned whatever the number of rating logo, so there is no more options that enlarge the zone.

Here you can see the result.

![Capture d’écran de 2019-03-18 20-56-40](https://user-images.githubusercontent.com/4435536/54560190-0baed100-49c2-11e9-9541-4bcc9b5630ed.png)
