### PR TITLE
💥 Change email destination to 'bcc' rather than 'to'

### DIFF
--- a/functions/email/index.js
+++ b/functions/email/index.js
@@ -24,7 +24,7 @@ module.exports.send = (config, {
   form.append('subject', subject)
   form.append('html', html)
   to.forEach((dest) => {
-    if (dest) form.append('to', dest)
+    if (dest) form.append('bcc', dest)
   })
   const cc = !isEmpty(contact) && /\S+@\S+\.\S+/.test(contact) ? contact : null
   if (cc) {


### PR DESCRIPTION
Change the destination of the emails to bcc to not disclose destination email for everyone. Helpful for Montpellier where we have multiple meetups on the same CH. 

I've read the contributing guidelines a little late. Maybe you can add the gitmoji to the commit message when merging the PR. 