### PR TITLE
:bug: workaround GCF env variable not set in node10

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,7 +19,7 @@ jobs:
 
   test:
     docker:
-      - image: circleci/node:10.16.0
+      - image: circleci/node:8.13.0
     steps:
       - checkout
       - restore_cache:

--- a/functions/package.json
+++ b/functions/package.json
@@ -3,7 +3,7 @@
   "description": "Cloud Functions for Firebase",
   "private": true,
   "engines": {
-    "node": "10"
+    "node": "^8.13.0"
   },
   "scripts": {
     "api": "firebase serve --only hosting,functions",

--- a/functions/package.json
+++ b/functions/package.json
@@ -3,7 +3,7 @@
   "description": "Cloud Functions for Firebase",
   "private": true,
   "engines": {
-    "node": "^8.13.0"
+    "node": "8"
   },
   "scripts": {
     "api": "firebase serve --only hosting,functions",


### PR DESCRIPTION
To work around this issue: https://github.com/firebase/firebase-functions/issues/437
which prevent the GCF function triggered on DB event to works ie: no email is sent.