### PR TITLE
:white_check_mark: Use a mocked function to avoid date related issues…

### DIFF
--- a/src/components/thread/__snapshots__/thread.spec.jsx.snap
+++ b/src/components/thread/__snapshots__/thread.spec.jsx.snap
@@ -81,7 +81,7 @@ exports[`components/thread should render a message in the thread 1`] = `
               <span
                 className="date"
               >
-                over 49 years ago
+                about 1 year ago
               </span>
               <span
                 className="modified"

--- a/src/components/thread/thread.spec.jsx
+++ b/src/components/thread/thread.spec.jsx
@@ -3,6 +3,8 @@ import React from 'react'
 import { mount } from 'enzyme'
 import Thread from './index'
 
+jest.mock('date-fns/distance_in_words_to_now', () => () => 'about 1 year ago')
+
 describe('components/thread', () => {
   it('should render a message in the thread', () => {
     const messages = [


### PR DESCRIPTION
… in tests

This fix a bug where every new PR can not pass test since the snapshot is not valid anymore