### PR TITLE
:pencil: document how to create serviceAccount.json

### DIFF
--- a/docs/app/installation.mdx
+++ b/docs/app/installation.mdx
@@ -20,6 +20,11 @@ Create a firebase project with the [firebase console](https://console.firebase.g
 * Activate "Google" as a sign-in provider for Authentication
 * Activate "Storage" (used to store event images for banners)
 
+Configure your Private Key :
+* Go to project's settings
+* Go to "Service accounts" tab, then go to "Firebase Admin SDK" section and click "Generate new private key"
+* Copy the downloaded file into your project root and rename it "serviceAccount.json"
+
 Create a `.env.local` file by copying `.env` file at root folder and set firebase environment variables. You can get all these variables from the homepage by clicking "Add an application" and selecting the web icon.
 
 * `REACT_APP_API_KEY=<API_KEY>`


### PR DESCRIPTION
related to https://github.com/bpetetot/conference-hall/issues/689

This commit add instruction on how to generate the serviceAccount.json from the firebase console and when to put it in the project.

I'm not sure if those instruction should be in the "Configure Firebase" section or in the "Cloud Functions" sections. Feel free to move them in the correct section.