### PR TITLE
:sparkles: add talk submission date to getEvent api

### DIFF
--- a/functions/api/v1/getEvent.js
+++ b/functions/api/v1/getEvent.js
@@ -22,6 +22,7 @@ module.exports = async (req, res) => {
           'speakers',
           'comments',
           'language',
+          'createTimestamp'
         ],
         speaker: ['uid', 'displayName', 'bio', 'speakerReferences', 'company', 'photoURL', 'twitter', 'github'],
       },


### PR DESCRIPTION
Hi,

For our event we would like to make some statistics on submissions dates so we can know if our tweets have an impact to the CFP progression.

The easiest way would be to use the API to get talks submissions date. So I propose to add this field to the firebase query.