### PR TITLE
:sparkles: managing organizer roles

### DIFF
--- a/config/firestore.rules
+++ b/config/firestore.rules
@@ -46,44 +46,45 @@ service cloud.firestore {
     }
 
     // EVENTS
-    function itsMyEvent() { return resource.data.owner == request.auth.uid || isOneOfRoles(get(/databases/$(database)/documents/organizations/$(resource.data.organization)), ['owner', 'member', 'reviewer']) }
-    function fromMyEvent(eventRes) { return eventRes.data.owner == request.auth.uid || isOneOfRoles(get(/databases/$(database)/documents/organizations/$(eventRes.data.organization)), ['owner', 'member', 'reviewer']) }
-    
+    function isValidNewEvent() { return authenticated() && request.resource.data.owner == request.auth.uid }
+    function itsMyEvent(rsc) { return rsc.data.owner == request.auth.uid || isOneOfRoles(get(/databases/$(database)/documents/organizations/$(rsc.data.organization)), ['owner', 'member', 'reviewer']) }
+    function canEditEvent(rsc) { return rsc.data.owner == request.auth.uid || isOneOfRoles(get(/databases/$(database)/documents/organizations/$(rsc.data.organization)), ['owner', 'member']) }
+  
     match /events/{event} {
     	allow get;
-    	allow list: if authenticated() && (isPublicEvent() || itsMyEvent());
-    	allow create: if authenticated();
-    	allow update: if authenticated() && itsMyEvent();
+    	allow list: if authenticated() && (isPublicEvent() || itsMyEvent(resource));
+    	allow create: if isValidNewEvent();
+    	allow update: if authenticated() && canEditEvent(resource);
 
       // SETTINGS
       match /settings/{id} {
-        allow get: if authenticated() && fromMyEvent(get(/databases/$(database)/documents/events/$(event)));
-        allow create: if authenticated() && fromMyEvent(get(/databases/$(database)/documents/events/$(event)));
-        allow update: if authenticated() && fromMyEvent(get(/databases/$(database)/documents/events/$(event)));
+        allow get: if authenticated() && itsMyEvent(get(/databases/$(database)/documents/events/$(event)));
+        allow create: if authenticated() && canEditEvent(get(/databases/$(database)/documents/events/$(event)));
+        allow update: if authenticated() && canEditEvent(get(/databases/$(database)/documents/events/$(event)));
       }
 
       // SURVEYS
       match /surveys/{survey} {
-        allow get: if authenticated() && (itsMySurvey() || fromMyEvent(get(/databases/$(database)/documents/events/$(event))));
+        allow get: if authenticated() && (itsMySurvey() || itsMyEvent(get(/databases/$(database)/documents/events/$(event))));
         allow create: if authenticated() && itsMySurvey();
         allow update: if authenticated() && itsMySurvey();
       }
 
       // PROPOSALS
       match /proposals/{proposal} {
-      	allow read: if authenticated() && fromMyEvent(get(/databases/$(database)/documents/events/$(event)));
-        allow write: if authenticated() && (itsMyProposal() || fromMyEvent(get(/databases/$(database)/documents/events/$(event))));
+      	allow read: if authenticated() && itsMyEvent(get(/databases/$(database)/documents/events/$(event)));
+        allow write: if authenticated() && (itsMyProposal() || itsMyEvent(get(/databases/$(database)/documents/events/$(event))));
 
         // RATINGS
         match /ratings/{rating} {
-          allow read: if authenticated() && fromMyEvent(get(/databases/$(database)/documents/events/$(event)));
-          allow write: if authenticated() && fromMyEvent(get(/databases/$(database)/documents/events/$(event)));
+          allow read: if authenticated() && itsMyEvent(get(/databases/$(database)/documents/events/$(event)));
+          allow write: if authenticated() && itsMyEvent(get(/databases/$(database)/documents/events/$(event)));
         }
 
         // ORGANIZERS THREAD
         match /organizersThread/{message} {
-          allow list: if authenticated() && fromMyEvent(get(/databases/$(database)/documents/events/$(event)));
-          allow create: if authenticated() && fromMyEvent(get(/databases/$(database)/documents/events/$(event)));
+          allow list: if authenticated() && canEditEvent(get(/databases/$(database)/documents/events/$(event)));
+          allow create: if authenticated() && canEditEvent(get(/databases/$(database)/documents/events/$(event)));
           allow update: if authenticated() && itsMyMessage(get(/databases/$(database)/documents/events/$(event)/proposals/$(proposal)/organizersThread/$(message)));
           allow delete: if authenticated() && itsMyMessage(get(/databases/$(database)/documents/events/$(event)/proposals/$(proposal)/organizersThread/$(message)));
         }

--- a/config/firestore.rules
+++ b/config/firestore.rules
@@ -5,16 +5,9 @@ service cloud.firestore {
     function limitOne() { return request.query.limit <= 1 }
     function userNotExists() { return !exists(/databases/$(database)/documents/users/$(request.auth.uid)) }
     function itsMe() { return request.resource.data.uid == request.auth.uid }
-    function itsMyOrganizations() { return resource.data.members[request.auth.uid] }
-    function itsMyEvent() { return resource.data.owner == request.auth.uid || get(/databases/$(database)/documents/organizations/$(resource.data.organization)).data.members[request.auth.uid] == true }
     function isPublicEvent() { return resource.data.visibility == 'public' }
     function itsMyTalk() { return resource.data.speakers[request.auth.uid] == true }
-    function itsMyProposal() {
-    	return get(/databases/$(database)/documents/talks/$(request.path[6])).data.speakers[request.auth.uid] == true
-    }
-    function fromMyEvent(eventRes) {
-    	return eventRes.data.owner == request.auth.uid || get(/databases/$(database)/documents/organizations/$(eventRes.data.organization)).data.members[request.auth.uid] == true
-    }
+    function itsMyProposal() { return get(/databases/$(database)/documents/talks/$(request.path[6])).data.speakers[request.auth.uid] == true }
     function itsMyMessage(message) { return request.auth.uid == message.data.uid }
 
 		function itsMySurvey() { return request.path[6] == request.auth.uid }
@@ -33,14 +26,29 @@ service cloud.firestore {
     }
 
     // ORGANIZATIONS
+    function isValidNewOrganization() {
+      return authenticated() && request.resource.data.members[request.auth.uid] == 'owner';
+    }
+
+    function getRole(rsc) {
+      return rsc.data.members[request.auth.uid];
+    }
+
+    function isOneOfRoles(rsc, array) {
+      return authenticated() && (getRole(rsc) in array);
+    }
+
     match /organizations/{organization} {
-    	allow get: if authenticated();
-    	allow list: if authenticated() && itsMyOrganizations();
-      allow create: if authenticated();
-      allow update: if authenticated() && itsMyOrganizations();
+    	allow get: if isOneOfRoles(resource, ['owner', 'member', 'reviewer']);
+    	allow list: if isOneOfRoles(resource, ['owner', 'member', 'reviewer']);
+      allow create: if isValidNewOrganization();
+      allow update: if isOneOfRoles(resource, ['owner']);
     }
 
     // EVENTS
+    function itsMyEvent() { return resource.data.owner == request.auth.uid || isOneOfRoles(get(/databases/$(database)/documents/organizations/$(resource.data.organization)), ['owner', 'member', 'reviewer']) }
+    function fromMyEvent(eventRes) { return eventRes.data.owner == request.auth.uid || isOneOfRoles(get(/databases/$(database)/documents/organizations/$(eventRes.data.organization)), ['owner', 'member', 'reviewer']) }
+    
     match /events/{event} {
     	allow get;
     	allow list: if authenticated() && (isPublicEvent() || itsMyEvent());
@@ -94,12 +102,12 @@ service cloud.firestore {
     // INVITES
     function canReadInvite() {
     	return (resource.data.entity == 'talk' && get(/databases/$(database)/documents/talks/$(resource.data.entityId)).data.speakers[request.auth.uid] == true)
-      || (resource.data.entity == 'organization' && get(/databases/$(database)/documents/organizations/$(resource.data.entityId)).data.members[request.auth.uid] == true)
+      || (resource.data.entity == 'organization' && isOneOfRoles(get(/databases/$(database)/documents/organizations/$(resource.data.entityId)), ['owner']))
     }
 
     function canCreateInvite() {
     	return (request.resource.data.entity == 'talk' && get(/databases/$(database)/documents/talks/$(request.resource.data.entityId)).data.speakers[request.auth.uid] == true)
-      || (request.resource.data.entity == 'organization' && get(/databases/$(database)/documents/organizations/$(request.resource.data.entityId)).data.members[request.auth.uid] == true)
+      || (request.resource.data.entity == 'organization' && isOneOfRoles(get(/databases/$(database)/documents/organizations/$(request.resource.data.entityId)), ['owner']))
     }
 
     function canDeleteInvite() {

--- a/config/firestore.rules.spec.js
+++ b/config/firestore.rules.spec.js
@@ -16,11 +16,11 @@ function createTalk(app, talkId, uid) {
     .set({ speakers: { [uid]: true } })
 }
 
-function createOrganization(app, organizationId, uid) {
+function createOrganization(app, organizationId, members) {
   return app
     .collection('organizations')
     .doc(organizationId)
-    .set({ members: { [uid]: true } })
+    .set({ members })
 }
 
 function createInvite(app, entity, entityId, uid) {
@@ -46,32 +46,128 @@ describe('Firestore rules', () => {
     await firebase.clearFirestoreData({ projectId })
   })
 
-  describe('Invites to a talk', () => {
+  describe('Collection "organizations"', () => {
+    it('can create an organization as owner', async () => {
+      const alice = authedApp({ uid: 'alice' })
+      const organization = createOrganization(alice, 'org1', { alice: 'owner' })
+      await firebase.assertSucceeds(organization)
+    })
+
+    it("can't create an organization if not set as owner", async () => {
+      const alice = authedApp({ uid: 'alice' })
+      const organization = createOrganization(alice, 'org1', { alice: 'member' })
+      await firebase.assertFails(organization)
+    })
+
+    it('can update an organization as owner', async () => {
+      const alice = authedApp({ uid: 'alice' })
+      await createOrganization(alice, 'org1', { alice: 'owner' })
+      const organization = alice
+        .collection('organizations')
+        .doc('org1')
+        .set({ name: 'new name' })
+      await firebase.assertSucceeds(organization)
+    })
+
+    it("can't update an organization if not owner", async () => {
+      const alice = authedApp({ uid: 'alice' })
+      const bob = authedApp({ uid: 'bob' })
+      const tom = authedApp({ uid: 'tom' })
+      await createOrganization(alice, 'org1', { alice: 'owner', bob: 'member', tom: 'reviewer' })
+      const update1 = bob
+        .collection('organizations')
+        .doc('org1')
+        .set({ name: 'new name' })
+      await firebase.assertFails(update1)
+      const update2 = tom
+        .collection('organizations')
+        .doc('org1')
+        .set({ name: 'new name' })
+      await firebase.assertFails(update2)
+    })
+
+    it('can get an organization if owner, member or reviewer', async () => {
+      const alice = authedApp({ uid: 'alice' })
+      const bob = authedApp({ uid: 'bob' })
+      const tom = authedApp({ uid: 'tom' })
+      await createOrganization(alice, 'org1', { alice: 'owner', bob: 'member', tom: 'reviewer' })
+      const readByOwner = alice
+        .collection('organizations')
+        .doc('org1')
+        .get()
+      await firebase.assertSucceeds(readByOwner)
+      const readByMember = bob
+        .collection('organizations')
+        .doc('org1')
+        .get()
+      await firebase.assertSucceeds(readByMember)
+      const readByReviewer = tom
+        .collection('organizations')
+        .doc('org1')
+        .get()
+      await firebase.assertSucceeds(readByReviewer)
+    })
+
+    it("can't get an organization if don't belong to it", async () => {
+      const alice = authedApp({ uid: 'alice' })
+      const stranger = authedApp({ uid: 'stranger' })
+      await createOrganization(alice, 'org1', { alice: 'owner' })
+      const readByStranger = stranger
+        .collection('organizations')
+        .doc('org1')
+        .get()
+      await firebase.assertFails(readByStranger)
+    })
+
+    it('can list organizations as owner, member and reviewer', async () => {
+      const alice = authedApp({ uid: 'alice' })
+      const bob = authedApp({ uid: 'bob' })
+      await createOrganization(alice, 'orgAsOwner', { alice: 'owner' })
+      await createOrganization(bob, 'orgAsMember', { bob: 'owner', alice: 'member' })
+      await createOrganization(bob, 'orgAsReviewer', { bob: 'owner', alice: 'reviewer' })
+      await createOrganization(bob, 'NoOrg', { bob: 'owner' })
+      const listOrgs = alice
+        .collection('organizations')
+        .where('members.alice', 'in', ['owner', 'member', 'reviewer'])
+        .get()
+      const result = await firebase.assertSucceeds(listOrgs)
+      expect(result.docs.length).toEqual(3)
+      expect(result.docs.map(org => org.id)).toEqual(['orgAsMember', 'orgAsOwner', 'orgAsReviewer'])
+    })
+
+    it("can't list organizations if no roles", async () => {
+      const alice = authedApp({ uid: 'alice' })
+      const bob = authedApp({ uid: 'bob' })
+      await createOrganization(bob, 'NoOrg', { bob: 'owner' })
+      const listOrgs = alice
+        .collection('organizations')
+        .where('members.alice', 'in', ['owner', 'member', 'reviewer'])
+        .get()
+      const result = await firebase.assertSucceeds(listOrgs)
+      expect(result.docs.length).toEqual(0)
+    })
+  })
+
+  describe('Collection "invites" - Invites to a talk', () => {
     it("can create an invite for it's talk", async () => {
       const alice = authedApp({ uid: 'alice' })
-
       await createTalk(alice, 'talk1', 'alice')
       const invite = createInvite(alice, 'talk', 'talk1', 'alice')
-
       await firebase.assertSucceeds(invite)
     })
 
     it("can't create an invite for someone else talk", async () => {
       const alice = authedApp({ uid: 'alice' })
       const marie = authedApp({ uid: 'marie' })
-
       await createTalk(marie, 'talk1', 'marie')
       const invite = createInvite(alice, 'talk', 'talk1', 'alice')
-
       await firebase.assertFails(invite)
     })
 
-    it("can list get invite for it's talk", async () => {
+    it("can get invite for it's talk", async () => {
       const alice = authedApp({ uid: 'alice' })
-
       await createTalk(alice, 'talk1', 'alice')
       await createInvite(alice, 'talk', 'talk1', 'alice')
-
       await firebase.assertSucceeds(
         alice
           .collection('invites')
@@ -84,10 +180,8 @@ describe('Firestore rules', () => {
     it("can't list get invite for someone else talk", async () => {
       const marie = authedApp({ uid: 'marie' })
       const alice = authedApp({ uid: 'alice' })
-
       await createTalk(marie, 'talk1', 'marie')
       await createInvite(marie, 'talk', 'talk1', 'marie')
-
       const invite = alice
         .collection('invites')
         .where('entity', '==', 'talk')
@@ -99,10 +193,8 @@ describe('Firestore rules', () => {
 
     it("can delete it's invite", async () => {
       const alice = authedApp({ uid: 'alice' })
-
       await createTalk(alice, 'talk1', 'alice')
       const { id } = await createInvite(alice, 'talk', 'talk1', 'alice')
-
       await firebase.assertSucceeds(
         alice
           .collection('invites')
@@ -114,10 +206,8 @@ describe('Firestore rules', () => {
     it("can't delete someone else invite", async () => {
       const alice = authedApp({ uid: 'alice' })
       const marie = authedApp({ uid: 'marie' })
-
       await createTalk(marie, 'talk1', 'marie')
       const { id } = await createInvite(marie, 'talk', 'talk1', 'marie')
-
       await firebase.assertFails(
         alice
           .collection('invites')
@@ -129,51 +219,41 @@ describe('Firestore rules', () => {
     it("everybody can access invite by it's id", async () => {
       const alice = authedApp({ uid: 'alice' })
       const marie = authedApp({ uid: 'marie' })
-
       await createTalk(marie, 'talk1', 'marie')
       const { id } = await createInvite(marie, 'talk', 'talk1', 'marie')
       const invite = alice.collection('invites').doc(id)
-
       await firebase.assertSucceeds(invite)
     })
 
     it('should be impossible to list all invites', async () => {
       const alice = authedApp({ uid: 'alice' })
-
       await createTalk(alice, 'talk1', 'alice')
       await createInvite(alice, 'talk', 'talk1', 'alice')
       const invites = alice.collection('invites').get()
-
       await firebase.assertFails(invites)
     })
   })
 
-  describe('Invites to an organization', () => {
+  describe('Collection "invites" - Invites to an organization', () => {
     it("can create an invite for it's organization", async () => {
       const alice = authedApp({ uid: 'alice' })
-
-      await createOrganization(alice, 'organization1', 'alice')
+      await createOrganization(alice, 'organization1', { alice: 'owner' })
       const invite = createInvite(alice, 'organization', 'organization1', 'alice')
-
       await firebase.assertSucceeds(invite)
     })
 
     it("can't create an invite for someone else organization", async () => {
       const alice = authedApp({ uid: 'alice' })
       const marie = authedApp({ uid: 'marie' })
-
-      await createOrganization(marie, 'organization1', 'marie')
+      await createOrganization(marie, 'organization1', { marie: 'owner' })
       const invite = createInvite(alice, 'organization', 'organization1', 'alice')
-
       await firebase.assertFails(invite)
     })
 
     it("can list get invite for it's organization", async () => {
       const alice = authedApp({ uid: 'alice' })
-
-      await createOrganization(alice, 'organization1', 'alice')
+      await createOrganization(alice, 'organization1', { alice: 'owner' })
       await createInvite(alice, 'organization', 'organization1', 'alice')
-
       await firebase.assertSucceeds(
         alice
           .collection('invites')
@@ -186,25 +266,20 @@ describe('Firestore rules', () => {
     it("can't list get invite for someone else organization", async () => {
       const marie = authedApp({ uid: 'marie' })
       const alice = authedApp({ uid: 'alice' })
-
-      await createOrganization(marie, 'organization1', 'marie')
+      await createOrganization(marie, 'organization1', { marie: 'owner' })
       await createInvite(marie, 'organization', 'organization1', 'marie')
-
       const invite = alice
         .collection('invites')
         .where('entity', '==', 'organization')
         .where('entityId', '==', 'organization1')
         .get()
-
       await firebase.assertFails(invite)
     })
 
     it("can delete it's invite", async () => {
       const alice = authedApp({ uid: 'alice' })
-
-      await createOrganization(alice, 'organization1', 'alice')
+      await createOrganization(alice, 'organization1', { alice: 'owner' })
       const { id } = await createInvite(alice, 'organization', 'organization1', 'alice')
-
       await firebase.assertSucceeds(
         alice
           .collection('invites')
@@ -216,10 +291,8 @@ describe('Firestore rules', () => {
     it("can't delete someone else invite", async () => {
       const alice = authedApp({ uid: 'alice' })
       const marie = authedApp({ uid: 'marie' })
-
-      await createOrganization(marie, 'organization1', 'marie')
+      await createOrganization(marie, 'organization1', { marie: 'owner' })
       const { id } = await createInvite(marie, 'organization', 'organization1', 'marie')
-
       await firebase.assertFails(
         alice
           .collection('invites')
@@ -231,21 +304,17 @@ describe('Firestore rules', () => {
     it("everybody can access invite by it's id", async () => {
       const alice = authedApp({ uid: 'alice' })
       const marie = authedApp({ uid: 'marie' })
-
-      await createOrganization(marie, 'organization1', 'marie')
+      await createOrganization(marie, 'organization1', { marie: 'owner' })
       const { id } = await createInvite(marie, 'organization', 'organization1', 'marie')
       const invite = alice.collection('invites').doc(id)
-
       await firebase.assertSucceeds(invite)
     })
 
     it('should be impossible to list all invites', async () => {
       const alice = authedApp({ uid: 'alice' })
-
-      await createOrganization(alice, 'organization1', 'alice')
+      await createOrganization(alice, 'organization1', { alice: 'owner' })
       await createInvite(alice, 'organization', 'organization1', 'alice')
       const invites = alice.collection('invites').get()
-
       await firebase.assertFails(invites)
     })
   })

--- a/functions/__mocks__/firebase-admin.js
+++ b/functions/__mocks__/firebase-admin.js
@@ -2,4 +2,9 @@ const firebase = require('@firebase/testing')
 
 const projectId = 'conference-hall'
 
-module.exports = firebase.initializeAdminApp({ projectId })
+const admin = firebase.initializeAdminApp({ projectId })
+
+// set FieldValue commands in the mock
+admin.firestore.FieldValue = firebase.firestore.FieldValue
+
+module.exports = admin

--- a/functions/direct/invite.js
+++ b/functions/direct/invite.js
@@ -11,7 +11,7 @@ const getInvite = inviteId =>
 
 const validateInvite = async ({ inviteId }, context) => {
   const { uid } = context.auth
-  const { entity, entityId } = await getInvite(inviteId)
+  const { entity, entityId, role = 'member' } = await getInvite(inviteId)
 
   // add to co-speaker
   if (entity === 'talk') {
@@ -28,7 +28,7 @@ const validateInvite = async ({ inviteId }, context) => {
       .firestore()
       .collection('organizations')
       .doc(entityId)
-      .update({ [`members.${uid}`]: true })
+      .update({ [`members.${uid}`]: role })
   }
 }
 

--- a/functions/direct/invite.js
+++ b/functions/direct/invite.js
@@ -9,9 +9,11 @@ const getInvite = inviteId =>
     .get()
     .then(doc => doc.data())
 
+const DEFAULT_ORGA_ROLE = 'reviewer'
+
 const validateInvite = async ({ inviteId }, context) => {
   const { uid } = context.auth
-  const { entity, entityId, role = 'member' } = await getInvite(inviteId)
+  const { entity, entityId } = await getInvite(inviteId)
 
   // add to co-speaker
   if (entity === 'talk') {
@@ -28,7 +30,7 @@ const validateInvite = async ({ inviteId }, context) => {
       .firestore()
       .collection('organizations')
       .doc(entityId)
-      .update({ [`members.${uid}`]: role })
+      .update({ [`members.${uid}`]: DEFAULT_ORGA_ROLE })
   }
 }
 

--- a/functions/direct/invite.spec.emul.js
+++ b/functions/direct/invite.spec.emul.js
@@ -68,7 +68,7 @@ describe('validateInvite', () => {
     await firebase.assertSucceeds(organization)
 
     const { members } = await organization.data()
-    expect(members).toEqual({ alice: 'owner', marie: 'member' })
+    expect(members).toEqual({ alice: 'owner', marie: 'reviewer' })
   })
 })
 

--- a/functions/direct/invite.spec.emul.js
+++ b/functions/direct/invite.spec.emul.js
@@ -25,7 +25,7 @@ function createOrganization({ organizationId, uid }) {
     .firestore()
     .collection('organizations')
     .doc(organizationId)
-    .set({ members: { [uid]: true } })
+    .set({ members: { [uid]: 'owner' } })
 }
 
 describe('validateInvite', () => {
@@ -68,7 +68,7 @@ describe('validateInvite', () => {
     await firebase.assertSucceeds(organization)
 
     const { members } = await organization.data()
-    expect(members).toEqual({ alice: true, marie: true })
+    expect(members).toEqual({ alice: 'owner', marie: 'member' })
   })
 })
 

--- a/functions/direct/organization.js
+++ b/functions/direct/organization.js
@@ -1,0 +1,21 @@
+const functions = require('firebase-functions')
+const admin = require('firebase-admin')
+
+const leaveOrganization = async ({ organizationId }, context) => {
+  const { uid } = context.auth
+
+  if (!organizationId || !uid) return
+
+  // leave the organization
+  await admin
+    .firestore()
+    .collection('organizations')
+    .doc(organizationId)
+    .update({
+      [`members.${uid}`]: admin.firestore.FieldValue.delete(),
+    })
+}
+
+module.exports = {
+  leaveOrganization: functions.https.onCall(leaveOrganization),
+}

--- a/functions/direct/organization.spec.emul.js
+++ b/functions/direct/organization.spec.emul.js
@@ -1,0 +1,47 @@
+/* eslint-env jest */
+const firebase = require('@firebase/testing')
+const admin = require('firebase-admin')
+
+const { leaveOrganization } = require('./organization')
+
+function createOrganization({ organizationId, members }) {
+  return admin
+    .firestore()
+    .collection('organizations')
+    .doc(organizationId)
+    .set({ members })
+}
+
+describe('createOrganization', () => {
+  afterAll(async () => {
+    await Promise.all(firebase.apps().map(app => app.delete()))
+  })
+
+  beforeEach(async () => {
+    await firebase.clearFirestoreData({ projectId: 'conference-hall' })
+  })
+
+  it('should remove the auth user from the organization', async () => {
+    await createOrganization({
+      organizationId: 'org1',
+      members: {
+        alice: 'owner',
+        bob: 'member',
+        tom: 'reviewer',
+      },
+    })
+    await leaveOrganization({ organizationId: 'org1' }, { auth: { uid: 'bob' } })
+
+    const organization = await admin
+      .firestore()
+      .collection('organizations')
+      .doc('org1')
+      .get()
+
+    const { members } = await organization.data()
+    expect(members).toEqual({ alice: 'owner', tom: 'reviewer' })
+  })
+})
+
+jest.mock('firebase-admin')
+jest.mock('firebase-functions')

--- a/functions/index.js
+++ b/functions/index.js
@@ -13,9 +13,11 @@ exports.api = require('./api')
 // functions for direct calls
 const { submitTalk, unsubmitTalk } = require('./direct/submission')
 const { validateInvite } = require('./direct/invite')
+const { leaveOrganization } = require('./direct/organization')
 const { delivered } = require('./email/emailWebhooks')
 
 exports.submitTalk = submitTalk
 exports.unsubmitTalk = unsubmitTalk
 exports.delivered = delivered
 exports.validateInvite = validateInvite
+exports.leaveOrganization = leaveOrganization

--- a/scripts/update-event-new-settings.js
+++ b/scripts/update-event-new-settings.js
@@ -8,7 +8,7 @@ const db = admin.firestore()
 const { updateEvents } = require('./helpers/updates')
 
 const main = async () => {
-  await updateEvents(async (event) => {
+  await updateEvents(async event => {
     const settings = {
       id: event.id,
       api: {

--- a/scripts/update-organization-roles.js
+++ b/scripts/update-organization-roles.js
@@ -1,0 +1,18 @@
+/* eslint-disable no-underscore-dangle, no-console */
+require('./helpers/initFirestore')
+
+const { updateOrganizations } = require('./helpers/updates')
+
+const main = async () => {
+  await updateOrganizations(async organization => {
+    const members = Object.keys(organization.members).reduce(
+      (acc, next) => ({ ...acc, [next]: 'owner' }),
+      {},
+    )
+    return {
+      members,
+    }
+  })
+}
+
+main()

--- a/src/components/avatar/__snapshots__/avatar.spec.jsx.snap
+++ b/src/components/avatar/__snapshots__/avatar.spec.jsx.snap
@@ -35,6 +35,7 @@ exports[`components/avatar should render with photo 1`] = `
   >
     <img
       alt="Benjamin"
+      loading="lazy"
       src="https://p.url"
     />
   </div>

--- a/src/components/avatar/avatar.jsx
+++ b/src/components/avatar/avatar.jsx
@@ -48,7 +48,7 @@ const Avatar = ({
   return (
     <div className={cn('cc-avatar-wrapper', className)}>
       <div className={classes} style={{ ...bgColor, ...style }}>
-        {src && <img src={src} alt={name || 'avatar'} />}
+        {src && <img src={src} alt={name || 'avatar'} loading="lazy" />}
         {!src && name && <span>{name.charAt(0)}</span>}
       </div>
       {withLabel && <span className={cn('cc-avatar-label', labelClassName)}>{name}</span>}

--- a/src/components/thread/__snapshots__/thread.spec.jsx.snap
+++ b/src/components/thread/__snapshots__/thread.spec.jsx.snap
@@ -62,6 +62,7 @@ exports[`components/thread should render a message in the thread 1`] = `
               >
                 <img
                   alt="Luke Skywalker"
+                  loading="lazy"
                   src="https://upload.wikimedia.org/wikipedia/en/9/9b/Luke_Skywalker.png"
                 />
               </div>

--- a/src/firebase/constants.js
+++ b/src/firebase/constants.js
@@ -1,0 +1,7 @@
+export const ROLES = {
+  OWNER: 'owner',
+  MEMBER: 'member',
+  REVIEWER: 'reviewer',
+}
+
+export const ROLE_OWNER_OR_MEMBER = [ROLES.OWNER, ROLES.MEMBER]

--- a/src/firebase/organizations.js
+++ b/src/firebase/organizations.js
@@ -1,14 +1,9 @@
 import firebase from 'firebase/app'
 
+import { ROLES } from './constants'
 import crud from './crud'
 
 const organizationCrud = crud('organizations', 'id')
-
-export const ROLES = {
-  OWNER: 'owner',
-  MEMBER: 'member',
-  REVIEWER: 'reviewer',
-}
 
 export const fetchUserOrganizations = uid =>
   firebase

--- a/src/firebase/organizations.js
+++ b/src/firebase/organizations.js
@@ -4,12 +4,19 @@ import crud from './crud'
 
 const organizationCrud = crud('organizations', 'id')
 
+export const ROLES = {
+  OWNER: 'owner',
+  MEMBER: 'member',
+  REVIEWER: 'reviewer',
+}
+
 export const fetchUserOrganizations = uid =>
   firebase
     .firestore()
     .collection('organizations')
-    .where(`members.${uid}`, '==', true)
+    .where(`members.${uid}`, 'in', Object.values(ROLES))
     .get()
+    .then(result => result.docs.map(ref => ({ id: ref.id, ...ref.data() })))
 
 export const fetchOrganizationEvents = organizationId =>
   firebase

--- a/src/firebase/user.js
+++ b/src/firebase/user.js
@@ -1,6 +1,8 @@
 import firebase from 'firebase/app'
 import crud from './crud'
 
+const userCrud = crud('users', 'uid')
+
 /**
  * Fetch user by email
  * @param {string} email user's email
@@ -15,4 +17,13 @@ export const fetchUsersByEmail = async email => {
   return result.docs.map(ref => ({ uid: ref.id, ...ref.data() }))
 }
 
-export default crud('users', 'uid')
+export const fetchUsersList = async (userIds = []) => {
+  return Promise.all(
+    userIds.map(async uid => {
+      const doc = await userCrud.read(uid)
+      return doc.data()
+    }),
+  )
+}
+
+export default userCrud

--- a/src/screens/components/addUserModal/addUserModal.jsx
+++ b/src/screens/components/addUserModal/addUserModal.jsx
@@ -55,7 +55,7 @@ const AddUserModal = ({
           {inviteEntity && inviteEntityId && (
             <div className={styles.inviteLink}>
               <div className={styles.separator}>
-                <small>If you can&apos;t find the user, send him/her an invitation link</small>
+                <small>If you can&apos;t find the user, share an invitation link</small>
               </div>
               <InviteLink
                 entity={inviteEntity}

--- a/src/screens/components/hasRole/hasRole.container.js
+++ b/src/screens/components/hasRole/hasRole.container.js
@@ -1,0 +1,16 @@
+import { inject } from '@k-ramel/react'
+
+import HasRole from './hasRole'
+
+const mapStore = (store, { of, forEventId, forOrganizationId }) => {
+  const event = store.data.events.get(forEventId)
+  const organization = store.data.organizations.get()[event?.organization ?? forOrganizationId]
+  const { uid } = store.auth.get()
+  const roles = Array.isArray(of) ? of : [of]
+
+  return {
+    authorized: roles.includes(organization?.members?.[uid]) || event.owner === uid,
+  }
+}
+
+export default inject(mapStore)(HasRole)

--- a/src/screens/components/hasRole/hasRole.js
+++ b/src/screens/components/hasRole/hasRole.js
@@ -1,0 +1,18 @@
+import { bool, node } from 'prop-types'
+
+const HasRole = ({ authorized, children }) => {
+  if (!authorized) return null
+
+  return children
+}
+
+HasRole.propTypes = {
+  authorized: bool,
+  children: node.isRequired,
+}
+
+HasRole.defaultProps = {
+  authorized: false,
+}
+
+export default HasRole

--- a/src/screens/components/hasRole/hasRole.jsx
+++ b/src/screens/components/hasRole/hasRole.jsx
@@ -1,7 +1,7 @@
 import { bool, node } from 'prop-types'
 
-const HasRole = ({ authorized, children }) => {
-  if (!authorized) return null
+const HasRole = ({ authorized, children, otherwise }) => {
+  if (!authorized) return otherwise
 
   return children
 }
@@ -9,10 +9,12 @@ const HasRole = ({ authorized, children }) => {
 HasRole.propTypes = {
   authorized: bool,
   children: node.isRequired,
+  otherwise: node,
 }
 
 HasRole.defaultProps = {
   authorized: false,
+  otherwise: null,
 }
 
 export default HasRole

--- a/src/screens/components/hasRole/index.js
+++ b/src/screens/components/hasRole/index.js
@@ -1,0 +1,1 @@
+export { default } from './hasRole.container'

--- a/src/screens/organizer/components/talkSelection/talkSelection.container.js
+++ b/src/screens/organizer/components/talkSelection/talkSelection.container.js
@@ -3,6 +3,7 @@ import { inject } from '@k-ramel/react'
 import TalkSelection from './talkSelection'
 
 const mapStore = (store, { proposalId }, { router }) => {
+  const eventId = router.getParam('eventId')
   const currentProposalId = proposalId || router.getParam('proposalId')
   const { emailStatus, state } = store.data.proposals.get(currentProposalId) || {}
 
@@ -11,6 +12,7 @@ const mapStore = (store, { proposalId }, { router }) => {
     (state === 'accepted' || state === 'rejected' || state === 'confirmed' || state === 'declined')
 
   return {
+    eventId,
     isDeliberationDone,
     emailStatus,
     state,

--- a/src/screens/organizer/components/talkSelection/talkSelection.jsx
+++ b/src/screens/organizer/components/talkSelection/talkSelection.jsx
@@ -1,70 +1,74 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import Badge from 'components/badge'
+import HasRole from 'screens/components/hasRole'
 
 import styles from './talkSelection.module.css'
 
-const TalkSelection = ({ onChange, state, emailStatus, isDeliberationDone }) => (
-  <div className={styles.wrapper}>
-    {isDeliberationDone && (
-      <div>
-        {state === 'accepted' && (
-          <Badge success outline>
+const TalkSelection = ({ eventId, onChange, state, emailStatus, isDeliberationDone }) => (
+  <HasRole of={['owner', 'member']} forEventId={eventId}>
+    <div className={styles.wrapper}>
+      {isDeliberationDone && (
+        <div>
+          {state === 'accepted' && (
+            <Badge success outline>
+              Accepted proposal
+            </Badge>
+          )}
+          {state === 'rejected' && (
+            <Badge error outline>
+              Rejected proposal
+            </Badge>
+          )}
+          {state === 'confirmed' && <Badge success>Confirmed by speaker</Badge>}
+          {state === 'declined' && <Badge error>Declined by speaker</Badge>}
+        </div>
+      )}
+
+      {!isDeliberationDone && (
+        <select
+          className={styles.selector}
+          onChange={onChange}
+          onClick={e => e.stopPropagation()}
+          defaultValue={state}
+        >
+          <option key="submitted" value="submitted">
+            Deliberate...
+          </option>
+          <option key="accepted" value="accepted">
             Accepted proposal
-          </Badge>
-        )}
-        {state === 'rejected' && (
-          <Badge error outline>
+          </option>
+          <option key="rejected" value="rejected">
             Rejected proposal
-          </Badge>
-        )}
-        {state === 'confirmed' && <Badge success>Confirmed by speaker</Badge>}
-        {state === 'declined' && <Badge error>Declined by speaker</Badge>}
-      </div>
-    )}
+          </option>
+        </select>
+      )}
 
-    {!isDeliberationDone && (
-      <select
-        className={styles.selector}
-        onChange={onChange}
-        onClick={e => e.stopPropagation()}
-        defaultValue={state}
-      >
-        <option key="submitted" value="submitted">
-          Deliberate...
-        </option>
-        <option key="accepted" value="accepted">
-          Accepted proposal
-        </option>
-        <option key="rejected" value="rejected">
-          Rejected proposal
-        </option>
-      </select>
-    )}
-
-    {emailStatus && emailStatus !== 'none' && (
-      <div className={styles.email}>
-        {emailStatus === 'sending' && (
-          <Badge light outline>
-            Sending email...
-          </Badge>
-        )}
-        {emailStatus === 'sent' && (
-          <Badge info outline>
-            Email sent
-          </Badge>
-        )}
-        {emailStatus === 'delivered' && (
-          <Badge success outline>
-            Email delivered
-          </Badge>
-        )}
-      </div>
-    )}
-  </div>
+      {emailStatus && emailStatus !== 'none' && (
+        <div className={styles.email}>
+          {emailStatus === 'sending' && (
+            <Badge light outline>
+              Sending email...
+            </Badge>
+          )}
+          {emailStatus === 'sent' && (
+            <Badge info outline>
+              Email sent
+            </Badge>
+          )}
+          {emailStatus === 'delivered' && (
+            <Badge success outline>
+              Email delivered
+            </Badge>
+          )}
+        </div>
+      )}
+    </div>
+  </HasRole>
 )
 
 TalkSelection.propTypes = {
+  eventId: PropTypes.string.isRequired,
   onChange: PropTypes.func.isRequired,
   state: PropTypes.string,
   emailStatus: PropTypes.string,

--- a/src/screens/organizer/components/talkSelection/talkSelection.jsx
+++ b/src/screens/organizer/components/talkSelection/talkSelection.jsx
@@ -2,11 +2,12 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import Badge from 'components/badge'
 import HasRole from 'screens/components/hasRole'
+import { ROLE_OWNER_OR_MEMBER } from 'firebase/constants'
 
 import styles from './talkSelection.module.css'
 
 const TalkSelection = ({ eventId, onChange, state, emailStatus, isDeliberationDone }) => (
-  <HasRole of={['owner', 'member']} forEventId={eventId}>
+  <HasRole of={ROLE_OWNER_OR_MEMBER} forEventId={eventId}>
     <div className={styles.wrapper}>
       {isDeliberationDone && (
         <div>

--- a/src/screens/organizer/event/edit/eventEdit.jsx
+++ b/src/screens/organizer/event/edit/eventEdit.jsx
@@ -2,6 +2,7 @@ import React from 'react'
 import PropTypes from 'prop-types'
 
 import HasRole from 'screens/components/hasRole'
+import { ROLE_OWNER_OR_MEMBER } from 'firebase/constants'
 
 import Tabs from './eventTabs'
 import EventForm from './eventForm'
@@ -13,7 +14,7 @@ import IntegrationsForm from './integrations'
 
 const EventEdit = ({ eventId }) => (
   <div>
-    <HasRole of={['owner', 'member']} forEventId={eventId}>
+    <HasRole of={ROLE_OWNER_OR_MEMBER} forEventId={eventId}>
       <Tabs eventId={eventId} />
       <EventForm eventId={eventId} />
       <CustomizeForm eventId={eventId} />

--- a/src/screens/organizer/event/edit/eventEdit.jsx
+++ b/src/screens/organizer/event/edit/eventEdit.jsx
@@ -1,6 +1,8 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 
+import HasRole from 'screens/components/hasRole'
+
 import Tabs from './eventTabs'
 import EventForm from './eventForm'
 import CustomizeForm from './customize'
@@ -11,13 +13,15 @@ import IntegrationsForm from './integrations'
 
 const EventEdit = ({ eventId }) => (
   <div>
-    <Tabs eventId={eventId} />
-    <EventForm eventId={eventId} />
-    <CustomizeForm eventId={eventId} />
-    <CfpForm eventId={eventId} />
-    <SurveyForm eventId={eventId} />
-    <DeliberationForm eventId={eventId} />
-    <IntegrationsForm eventId={eventId} />
+    <HasRole of={['owner', 'member']} forEventId={eventId}>
+      <Tabs eventId={eventId} />
+      <EventForm eventId={eventId} />
+      <CustomizeForm eventId={eventId} />
+      <CfpForm eventId={eventId} />
+      <SurveyForm eventId={eventId} />
+      <DeliberationForm eventId={eventId} />
+      <IntegrationsForm eventId={eventId} />
+    </HasRole>
   </div>
 )
 

--- a/src/screens/organizer/organization/page/addMember/addMember.jsx
+++ b/src/screens/organizer/organization/page/addMember/addMember.jsx
@@ -5,9 +5,9 @@ import AddUserModal from 'screens/components/addUserModal'
 import IconLabel from 'components/iconLabel'
 import Button from 'components/button'
 
-const AddMember = ({ organizationId, organizationName, onSelectUser }) => (
+const AddMember = ({ organizationId, organizationName, addMember }) => (
   <AddUserModal
-    onSelectUser={onSelectUser}
+    onSelectUser={addMember}
     resultsMessage="Select an organizer to add to your organization"
     description={
       <>
@@ -36,7 +36,7 @@ const AddMember = ({ organizationId, organizationName, onSelectUser }) => (
 AddMember.propTypes = {
   organizationId: PropTypes.string.isRequired,
   organizationName: PropTypes.string.isRequired,
-  onSelectUser: PropTypes.func.isRequired,
+  addMember: PropTypes.func.isRequired,
 }
 
 export default AddMember

--- a/src/screens/organizer/organization/page/addMember/addMember.jsx
+++ b/src/screens/organizer/organization/page/addMember/addMember.jsx
@@ -12,12 +12,13 @@ const AddMember = ({ organizationId, organizationName, onSelectUser }) => (
     description={
       <>
         <p>
-          Search and add a member to your organization, he/she will be also able to update it,
-          invite other members and create events for your organization.
+          Add or invite a member to your organization. By default, the new member will have{' '}
+          <strong>the role of &ldquo;Reviewer&rdquo;.</strong> You can changed it once the user is
+          added.
         </p>
         <p>
-          For security and privacy reasons, you can search a member only by his/her registered email
-          address. The member must already have a Conference Hall account.
+          For security and privacy reasons, you can search a member only by the registered email
+          address. <strong>The member must already have a Conference Hall account.</strong>
         </p>
       </>
     }

--- a/src/screens/organizer/organization/page/changeRole/changeRole.container.js
+++ b/src/screens/organizer/organization/page/changeRole/changeRole.container.js
@@ -1,0 +1,21 @@
+import { compose } from 'redux'
+import { inject } from '@k-ramel/react'
+
+import ChangeRole from './changeRole'
+
+const mapStore = (store, { uid, organizationId }) => {
+  const user = store.data.users.get(uid)
+  const { uid: userId } = store.auth.get()
+
+  return {
+    displayName: user?.displayName,
+    isAuthenticatedUser: userId === uid,
+    changeMemberRole: role =>
+      store.dispatch({
+        type: '@@ui/CHANGE_ORGANIZATION_MEMBER_ROLE',
+        payload: { uid, role, organizationId },
+      }),
+  }
+}
+
+export default compose(inject(mapStore))(ChangeRole)

--- a/src/screens/organizer/organization/page/changeRole/changeRole.container.js
+++ b/src/screens/organizer/organization/page/changeRole/changeRole.container.js
@@ -3,17 +3,15 @@ import { inject } from '@k-ramel/react'
 
 import ChangeRole from './changeRole'
 
-const mapStore = (store, { uid, organizationId }) => {
-  const user = store.data.users.get(uid)
+const mapStore = (store, { user, organizationId }) => {
   const { uid: userId } = store.auth.get()
 
   return {
-    displayName: user?.displayName,
-    isAuthenticatedUser: userId === uid,
+    isAuthenticatedUser: userId === user.uid,
     changeMemberRole: role =>
       store.dispatch({
         type: '@@ui/CHANGE_ORGANIZATION_MEMBER_ROLE',
-        payload: { uid, role, organizationId },
+        payload: { uid: user.uid, role, organizationId },
       }),
   }
 }

--- a/src/screens/organizer/organization/page/changeRole/changeRole.jsx
+++ b/src/screens/organizer/organization/page/changeRole/changeRole.jsx
@@ -1,7 +1,9 @@
 import React, { useState } from 'react'
 import PropTypes from 'prop-types'
+import capitalize from 'lodash/capitalize'
 
 import { ConfirmationPopin } from 'components/portals'
+import { ROLES } from 'firebase/constants'
 
 import RoleText from './roleText'
 
@@ -26,15 +28,11 @@ const ChangeRoleSelect = ({ user, role, isAuthenticatedUser, changeMemberRole })
             show()
           }}
         >
-          <option key="owner" value="owner">
-            Owner
-          </option>
-          <option key="member" value="member">
-            Member
-          </option>
-          <option key="reviewer" value="reviewer">
-            Reviewer
-          </option>
+          {Object.values(ROLES).map(roleOption => (
+            <option key={roleOption} value={roleOption}>
+              {capitalize(roleOption)}
+            </option>
+          ))}
         </select>
       )}
     />
@@ -49,7 +47,7 @@ ChangeRoleSelect.propTypes = {
 }
 
 ChangeRoleSelect.defaultProps = {
-  role: 'reviewer',
+  role: ROLES.REVIEWER,
 }
 
 export default ChangeRoleSelect

--- a/src/screens/organizer/organization/page/changeRole/changeRole.jsx
+++ b/src/screens/organizer/organization/page/changeRole/changeRole.jsx
@@ -5,7 +5,7 @@ import { ConfirmationPopin } from 'components/portals'
 
 import RoleText from './roleText'
 
-const ChangeRoleSelect = ({ displayName, role, isAuthenticatedUser, changeMemberRole }) => {
+const ChangeRoleSelect = ({ user, role, isAuthenticatedUser, changeMemberRole }) => {
   const [selectedRole, setSelectedRole] = useState(role)
 
   if (isAuthenticatedUser) return null
@@ -13,7 +13,7 @@ const ChangeRoleSelect = ({ displayName, role, isAuthenticatedUser, changeMember
   return (
     <ConfirmationPopin
       title="Change member role"
-      content={<RoleText displayName={displayName} role={selectedRole} />}
+      content={<RoleText displayName={user.displayName} role={selectedRole} />}
       onOk={() => changeMemberRole(selectedRole)}
       onCancel={() => setSelectedRole(role)}
       withCancel
@@ -42,14 +42,13 @@ const ChangeRoleSelect = ({ displayName, role, isAuthenticatedUser, changeMember
 }
 
 ChangeRoleSelect.propTypes = {
-  displayName: PropTypes.string,
+  user: PropTypes.object.isRequired,
   isAuthenticatedUser: PropTypes.bool.isRequired,
   role: PropTypes.string,
   changeMemberRole: PropTypes.func.isRequired,
 }
 
 ChangeRoleSelect.defaultProps = {
-  displayName: undefined,
   role: 'reviewer',
 }
 

--- a/src/screens/organizer/organization/page/changeRole/changeRole.jsx
+++ b/src/screens/organizer/organization/page/changeRole/changeRole.jsx
@@ -1,0 +1,56 @@
+import React, { useState } from 'react'
+import PropTypes from 'prop-types'
+
+import { ConfirmationPopin } from 'components/portals'
+
+import RoleText from './roleText'
+
+const ChangeRoleSelect = ({ displayName, role, isAuthenticatedUser, changeMemberRole }) => {
+  const [selectedRole, setSelectedRole] = useState(role)
+
+  if (isAuthenticatedUser) return null
+
+  return (
+    <ConfirmationPopin
+      title="Change member role"
+      content={<RoleText displayName={displayName} role={selectedRole} />}
+      onOk={() => changeMemberRole(selectedRole)}
+      onCancel={() => setSelectedRole(role)}
+      withCancel
+      renderTrigger={({ show }) => (
+        <select
+          value={selectedRole}
+          onChange={e => {
+            e.stopPropagation()
+            setSelectedRole(e.target.value)
+            show()
+          }}
+        >
+          <option key="owner" value="owner">
+            Owner
+          </option>
+          <option key="member" value="member">
+            Member
+          </option>
+          <option key="reviewer" value="reviewer">
+            Reviewer
+          </option>
+        </select>
+      )}
+    />
+  )
+}
+
+ChangeRoleSelect.propTypes = {
+  displayName: PropTypes.string,
+  isAuthenticatedUser: PropTypes.bool.isRequired,
+  role: PropTypes.string,
+  changeMemberRole: PropTypes.func.isRequired,
+}
+
+ChangeRoleSelect.defaultProps = {
+  displayName: undefined,
+  role: 'reviewer',
+}
+
+export default ChangeRoleSelect

--- a/src/screens/organizer/organization/page/changeRole/index.js
+++ b/src/screens/organizer/organization/page/changeRole/index.js
@@ -1,0 +1,1 @@
+export { default } from './changeRole.container'

--- a/src/screens/organizer/organization/page/changeRole/roleText.jsx
+++ b/src/screens/organizer/organization/page/changeRole/roleText.jsx
@@ -1,0 +1,41 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+
+const RoleText = ({ displayName, role }) => {
+  const title = `Set role “${role}” to “${displayName}” in the organization.`
+  const subtitle = `The role “${role}” will allow to:`
+
+  return (
+    <>
+      <p>{title}</p>
+      <p>{subtitle}</p>
+      {role === 'reviewer' && (
+        <ul>
+          <li>Review proposals</li>
+        </ul>
+      )}
+      {role === 'member' && (
+        <ul>
+          <li>Mannage events of the organization</li>
+          <li>Manage proposals</li>
+          <li>Review proposals</li>
+        </ul>
+      )}
+      {role === 'owner' && (
+        <ul>
+          <li>Manage the organization</li>
+          <li>Mannage events of the organization</li>
+          <li>Manage proposals</li>
+          <li>Review proposals</li>
+        </ul>
+      )}
+    </>
+  )
+}
+
+RoleText.propTypes = {
+  displayName: PropTypes.string.isRequired,
+  role: PropTypes.string.isRequired,
+}
+
+export default RoleText

--- a/src/screens/organizer/organization/page/changeRole/roleText.jsx
+++ b/src/screens/organizer/organization/page/changeRole/roleText.jsx
@@ -1,6 +1,8 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 
+import { ROLES } from 'firebase/constants'
+
 const RoleText = ({ displayName, role }) => {
   const title = `Set role “${role}” to “${displayName}” in the organization.`
   const subtitle = `The role “${role}” will allow to:`
@@ -9,19 +11,19 @@ const RoleText = ({ displayName, role }) => {
     <>
       <p>{title}</p>
       <p>{subtitle}</p>
-      {role === 'reviewer' && (
+      {role === ROLES.REVIEWER && (
         <ul>
           <li>Review proposals</li>
         </ul>
       )}
-      {role === 'member' && (
+      {role === ROLES.MEMBER && (
         <ul>
           <li>Mannage events of the organization</li>
           <li>Manage proposals</li>
           <li>Review proposals</li>
         </ul>
       )}
-      {role === 'owner' && (
+      {role === ROLES.OWNER && (
         <ul>
           <li>Manage the organization</li>
           <li>Mannage events of the organization</li>

--- a/src/screens/organizer/organization/page/memberRow/memberRow.container.js
+++ b/src/screens/organizer/organization/page/memberRow/memberRow.container.js
@@ -1,13 +1,9 @@
-import { compose } from 'redux'
 import { inject } from '@k-ramel/react'
-import loader from 'hoc-react-loader/build/core'
 
 import MemberRow from './memberRow'
 
-const mapStore = (store, { uid }, { router }) => ({
+const mapStore = (store, _, { router }) => ({
   organizationId: router.getParam('organizationId'),
-  ...store.data.users.get(uid),
-  load: () => store.dispatch({ type: '@@ui/FETCH_USER', payload: uid }),
 })
 
-export default compose(inject(mapStore), loader())(MemberRow)
+export default inject(mapStore)(MemberRow)

--- a/src/screens/organizer/organization/page/memberRow/memberRow.container.js
+++ b/src/screens/organizer/organization/page/memberRow/memberRow.container.js
@@ -4,12 +4,10 @@ import loader from 'hoc-react-loader/build/core'
 
 import MemberRow from './memberRow'
 
-const mapStore = (store, { uid }) => ({
+const mapStore = (store, { uid }, { router }) => ({
+  organizationId: router.getParam('organizationId'),
   ...store.data.users.get(uid),
   load: () => store.dispatch({ type: '@@ui/FETCH_USER', payload: uid }),
 })
 
-export default compose(
-  inject(mapStore), //
-  loader(), //
-)(MemberRow)
+export default compose(inject(mapStore), loader())(MemberRow)

--- a/src/screens/organizer/organization/page/memberRow/memberRow.css
+++ b/src/screens/organizer/organization/page/memberRow/memberRow.css
@@ -1,8 +1,0 @@
-.remove-member-modal > h1 {
-  color: var(--error-color);
-  margin-bottom: 1.5em;
-}
-
-.remove-member-modal a {
-  margin-top: 2em;
-}

--- a/src/screens/organizer/organization/page/memberRow/memberRow.jsx
+++ b/src/screens/organizer/organization/page/memberRow/memberRow.jsx
@@ -10,7 +10,7 @@ import ChangeRole from '../changeRole'
 import RemoveMemberButton from '../removeMember'
 import styles from './memberRow.module.css'
 
-const MemberRow = ({ organizationId, user, role, isOwner, removeMember, authUserId }) => {
+const MemberRow = ({ organizationId, user, role, isOwner, authUserId }) => {
   const { uid, displayName, photoURL } = user
   if (!displayName) return null
 
@@ -21,9 +21,9 @@ const MemberRow = ({ organizationId, user, role, isOwner, removeMember, authUser
       renderActions={() => (
         <div className={styles.actions}>
           <RemoveMemberButton
+            organizationId={organizationId}
             user={user}
             isOwner={isOwner}
-            removeMember={removeMember}
             authUserId={authUserId}
           />
           <HasRole
@@ -48,7 +48,6 @@ MemberRow.propTypes = {
   user: PropTypes.object.isRequired,
   role: PropTypes.string,
   isOwner: PropTypes.bool.isRequired,
-  removeMember: PropTypes.func.isRequired,
   authUserId: PropTypes.string.isRequired,
 }
 

--- a/src/screens/organizer/organization/page/memberRow/memberRow.jsx
+++ b/src/screens/organizer/organization/page/memberRow/memberRow.jsx
@@ -9,16 +9,8 @@ import ChangeRole from '../changeRole'
 import RemoveMemberButton from '../removeMember'
 import styles from './memberRow.module.css'
 
-const MemberRow = ({
-  organizationId,
-  uid,
-  displayName,
-  photoURL,
-  role,
-  isOwner,
-  removeMember,
-  authUserId,
-}) => {
+const MemberRow = ({ organizationId, user, role, isOwner, removeMember, authUserId }) => {
+  const { uid, displayName, photoURL } = user
   if (!displayName) return null
 
   return (
@@ -28,11 +20,10 @@ const MemberRow = ({
       renderActions={() => (
         <div className={styles.actions}>
           <HasRole of={['owner']} forOrganizationId={organizationId}>
-            <ChangeRole organizationId={organizationId} uid={uid} role={role} />
+            <ChangeRole organizationId={organizationId} user={user} role={role} />
           </HasRole>
           <RemoveMemberButton
-            uid={uid}
-            displayName={displayName}
+            user={user}
             isOwner={isOwner}
             removeMember={removeMember}
             authUserId={authUserId}
@@ -45,18 +36,15 @@ const MemberRow = ({
 
 MemberRow.propTypes = {
   organizationId: PropTypes.string.isRequired,
-  uid: PropTypes.string.isRequired,
-  displayName: PropTypes.string,
-  photoURL: PropTypes.string,
-  role: PropTypes.string.isRequired,
+  user: PropTypes.object.isRequired,
+  role: PropTypes.string,
   isOwner: PropTypes.bool.isRequired,
   removeMember: PropTypes.func.isRequired,
   authUserId: PropTypes.string.isRequired,
 }
 
 MemberRow.defaultProps = {
-  displayName: undefined,
-  photoURL: undefined,
+  role: 'reviewer',
 }
 
 export default MemberRow

--- a/src/screens/organizer/organization/page/memberRow/memberRow.jsx
+++ b/src/screens/organizer/organization/page/memberRow/memberRow.jsx
@@ -5,6 +5,7 @@ import { ListItem } from 'components/list'
 import Avatar from 'components/avatar'
 import Badge from 'components/badge'
 import HasRole from 'screens/components/hasRole'
+import { ROLES } from 'firebase/constants'
 
 import ChangeRole from '../changeRole'
 import RemoveMemberButton from '../removeMember'
@@ -27,7 +28,7 @@ const MemberRow = ({ organizationId, user, role, isOwner, authUserId }) => {
             authUserId={authUserId}
           />
           <HasRole
-            of={['owner']}
+            of={ROLES.OWNER}
             forOrganizationId={organizationId}
             otherwise={
               <Badge light pill outline>
@@ -52,7 +53,7 @@ MemberRow.propTypes = {
 }
 
 MemberRow.defaultProps = {
-  role: 'reviewer',
+  role: ROLES.REVIEWER,
 }
 
 export default MemberRow

--- a/src/screens/organizer/organization/page/memberRow/memberRow.jsx
+++ b/src/screens/organizer/organization/page/memberRow/memberRow.jsx
@@ -2,36 +2,29 @@ import React from 'react'
 import PropTypes from 'prop-types'
 
 import IconLabel from 'components/iconLabel'
-import RelativeDate from 'components/relativeDate'
 import Button from 'components/button'
 import { ListItem } from 'components/list'
 import { ConfirmationPopin } from 'components/portals'
 import Avatar from 'components/avatar/avatar'
 
-import { toDate } from 'helpers/firebase'
-
 import './memberRow.css'
 
-const MemberRow = ({
-  uid,
-  displayName,
-  photoURL,
-  updateTimestamp,
-  owner,
-  removeMember,
-  authUserId,
-}) => {
+const MemberRow = ({ uid, displayName, photoURL, role, isOwner, removeMember, authUserId }) => {
   if (!displayName) return null
 
-  const canRemove = owner === authUserId && owner !== uid
-  const canLeave = owner !== authUserId && authUserId === uid
+  const canRemove = isOwner && authUserId !== uid
+  const canLeave = authUserId === uid
 
   return (
     <>
       <ListItem
         key={uid}
-        title={<Avatar name={displayName} src={photoURL} withLabel />}
-        subtitle={<RelativeDate date={toDate(updateTimestamp)} />}
+        title={
+          <>
+            <Avatar name={displayName} src={photoURL} withLabel />
+            {role}
+          </>
+        }
         renderActions={() => (
           <ConfirmationPopin
             title={canRemove ? 'Remove a member' : 'Leave organization'}
@@ -66,8 +59,8 @@ MemberRow.propTypes = {
   uid: PropTypes.string.isRequired,
   displayName: PropTypes.string,
   photoURL: PropTypes.string,
-  updateTimestamp: PropTypes.any,
-  owner: PropTypes.string.isRequired,
+  role: PropTypes.string.isRequired,
+  isOwner: PropTypes.bool.isRequired,
   removeMember: PropTypes.func.isRequired,
   authUserId: PropTypes.string.isRequired,
 }
@@ -75,7 +68,6 @@ MemberRow.propTypes = {
 MemberRow.defaultProps = {
   displayName: undefined,
   photoURL: undefined,
-  updateTimestamp: undefined,
 }
 
 export default MemberRow

--- a/src/screens/organizer/organization/page/memberRow/memberRow.jsx
+++ b/src/screens/organizer/organization/page/memberRow/memberRow.jsx
@@ -2,7 +2,8 @@ import React from 'react'
 import PropTypes from 'prop-types'
 
 import { ListItem } from 'components/list'
-import Avatar from 'components/avatar/avatar'
+import Avatar from 'components/avatar'
+import Badge from 'components/badge'
 import HasRole from 'screens/components/hasRole'
 
 import ChangeRole from '../changeRole'
@@ -19,15 +20,23 @@ const MemberRow = ({ organizationId, user, role, isOwner, removeMember, authUser
       title={<Avatar name={displayName} src={photoURL} withLabel />}
       renderActions={() => (
         <div className={styles.actions}>
-          <HasRole of={['owner']} forOrganizationId={organizationId}>
-            <ChangeRole organizationId={organizationId} user={user} role={role} />
-          </HasRole>
           <RemoveMemberButton
             user={user}
             isOwner={isOwner}
             removeMember={removeMember}
             authUserId={authUserId}
           />
+          <HasRole
+            of={['owner']}
+            forOrganizationId={organizationId}
+            otherwise={
+              <Badge light pill outline>
+                {role}
+              </Badge>
+            }
+          >
+            <ChangeRole organizationId={organizationId} user={user} role={role} />
+          </HasRole>
         </div>
       )}
     />

--- a/src/screens/organizer/organization/page/memberRow/memberRow.jsx
+++ b/src/screens/organizer/organization/page/memberRow/memberRow.jsx
@@ -1,61 +1,50 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 
-import IconLabel from 'components/iconLabel'
-import Button from 'components/button'
 import { ListItem } from 'components/list'
-import { ConfirmationPopin } from 'components/portals'
 import Avatar from 'components/avatar/avatar'
+import HasRole from 'screens/components/hasRole'
 
-import './memberRow.css'
+import ChangeRole from '../changeRole'
+import RemoveMemberButton from '../removeMember'
+import styles from './memberRow.module.css'
 
-const MemberRow = ({ uid, displayName, photoURL, role, isOwner, removeMember, authUserId }) => {
+const MemberRow = ({
+  organizationId,
+  uid,
+  displayName,
+  photoURL,
+  role,
+  isOwner,
+  removeMember,
+  authUserId,
+}) => {
   if (!displayName) return null
 
-  const canRemove = isOwner && authUserId !== uid
-  const canLeave = authUserId === uid
-
   return (
-    <>
-      <ListItem
-        key={uid}
-        title={
-          <>
-            <Avatar name={displayName} src={photoURL} withLabel />
-            {role}
-          </>
-        }
-        renderActions={() => (
-          <ConfirmationPopin
-            title={canRemove ? 'Remove a member' : 'Leave organization'}
-            content={`Are you sure you want to ${
-              canRemove ? `remove ${displayName} from` : 'leave'
-            } organization ?`}
-            className="remove-member-modal"
-            onOk={removeMember}
-            withCancel
-            renderTrigger={({ show }) => (
-              <>
-                {canRemove && (
-                  <Button onClick={show} tertiary>
-                    <IconLabel icon="fa fa-trash" label="Remove" />
-                  </Button>
-                )}
-                {canLeave && (
-                  <Button onClick={show} tertiary>
-                    <IconLabel icon="fa fa-sign-out" label="Leave" />
-                  </Button>
-                )}
-              </>
-            )}
+    <ListItem
+      key={uid}
+      title={<Avatar name={displayName} src={photoURL} withLabel />}
+      renderActions={() => (
+        <div className={styles.actions}>
+          <HasRole of={['owner']} forOrganizationId={organizationId}>
+            <ChangeRole organizationId={organizationId} uid={uid} role={role} />
+          </HasRole>
+          <RemoveMemberButton
+            uid={uid}
+            displayName={displayName}
+            isOwner={isOwner}
+            removeMember={removeMember}
+            authUserId={authUserId}
           />
-        )}
-      />
-    </>
+        </div>
+      )}
+    />
   )
 }
 
 MemberRow.propTypes = {
+  organizationId: PropTypes.string.isRequired,
   uid: PropTypes.string.isRequired,
   displayName: PropTypes.string,
   photoURL: PropTypes.string,

--- a/src/screens/organizer/organization/page/memberRow/memberRow.module.css
+++ b/src/screens/organizer/organization/page/memberRow/memberRow.module.css
@@ -1,0 +1,3 @@
+.actions {
+  display: flex;
+}

--- a/src/screens/organizer/organization/page/memberRow/memberRow.module.css
+++ b/src/screens/organizer/organization/page/memberRow/memberRow.module.css
@@ -1,3 +1,4 @@
 .actions {
   display: flex;
+  align-items: center;
 }

--- a/src/screens/organizer/organization/page/organizationPage.container.js
+++ b/src/screens/organizer/organization/page/organizationPage.container.js
@@ -18,8 +18,6 @@ const mapStore = (store, _, { router }) => {
     load: () => store.dispatch('@@ui/ON_LOAD_ORGANIZATION'),
     addMember: uid =>
       store.dispatch({ type: '@@ui/ADD_ORGANIZATION_MEMBER', payload: { uid, organizationId } }),
-    removeMember: uid =>
-      store.dispatch({ type: '@@ui/REMOVE_ORGANIZATION_MEMBER', payload: { uid, organizationId } }),
   }
 }
 

--- a/src/screens/organizer/organization/page/organizationPage.container.js
+++ b/src/screens/organizer/organization/page/organizationPage.container.js
@@ -16,7 +16,7 @@ const mapStore = (store, _, { router }) => {
     ...organization,
     authUserId: userId,
     load: () => store.dispatch('@@ui/ON_LOAD_ORGANIZATION'),
-    onSelectUser: uid =>
+    addMember: uid =>
       store.dispatch({ type: '@@ui/ADD_ORGANIZATION_MEMBER', payload: { uid, organizationId } }),
     removeMember: uid =>
       store.dispatch({ type: '@@ui/REMOVE_ORGANIZATION_MEMBER', payload: { uid, organizationId } }),

--- a/src/screens/organizer/organization/page/organizationPage.jsx
+++ b/src/screens/organizer/organization/page/organizationPage.jsx
@@ -1,12 +1,12 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import { Link } from '@k-redux-router/react-k-ramel'
-import keys from 'lodash/keys'
 
 import Titlebar from 'components/titlebar'
 import { List } from 'components/list'
 import IconLabel from 'components/iconLabel'
 import Button from 'components/button'
+import HasRole from 'screens/components/hasRole'
 
 import AddMember from './addMember'
 import MemberRow from './memberRow'
@@ -18,46 +18,54 @@ const OrganizationPage = ({
   members,
   onSelectUser,
   removeMember,
-  owner,
   authUserId,
-}) => (
-  <div className="organization-page">
-    <Titlebar className="organization-header" icon="fa fa-users" title={name}>
-      <Button secondary>
-        {btn => (
-          <Link code="organizer-organization-edit" organizationId={organizationId} className={btn}>
-            <IconLabel icon="fa fa-pencil" label="Edit" />
-          </Link>
+}) => {
+  const isOwner = members[authUserId] === 'owner'
+  return (
+    <div className="organization-page">
+      <Titlebar className="organization-header" icon="fa fa-users" title={name}>
+        <HasRole of={['owner']} forOrganizationId={organizationId}>
+          <Button secondary>
+            {btn => (
+              <Link
+                code="organizer-organization-edit"
+                organizationId={organizationId}
+                className={btn}
+              >
+                <IconLabel icon="fa fa-pencil" label="Edit" />
+              </Link>
+            )}
+          </Button>
+          <AddMember
+            organizationId={organizationId}
+            organizationName={name}
+            onSelectUser={onSelectUser}
+          />
+        </HasRole>
+      </Titlebar>
+      <List
+        className="organization-content"
+        array={Object.entries(members)}
+        noResult="No users yet !"
+        renderRow={([uid, role]) => (
+          <MemberRow
+            key={uid}
+            uid={uid}
+            role={role}
+            authUserId={authUserId}
+            removeMember={() => removeMember(uid)}
+            isOwner={isOwner}
+          />
         )}
-      </Button>
-      <AddMember
-        organizationId={organizationId}
-        organizationName={name}
-        onSelectUser={onSelectUser}
       />
-    </Titlebar>
-    <List
-      className="organization-content"
-      array={keys(members)}
-      noResult="No users yet !"
-      renderRow={uid => (
-        <MemberRow
-          key={uid}
-          uid={uid}
-          authUserId={authUserId}
-          removeMember={() => removeMember(uid)}
-          owner={owner}
-        />
-      )}
-    />
-  </div>
-)
+    </div>
+  )
+}
 
 OrganizationPage.propTypes = {
   id: PropTypes.string.isRequired,
   name: PropTypes.string.isRequired,
-  members: PropTypes.objectOf(PropTypes.bool),
-  owner: PropTypes.string.isRequired,
+  members: PropTypes.objectOf(PropTypes.string),
   authUserId: PropTypes.string.isRequired,
   onSelectUser: PropTypes.func.isRequired,
   removeMember: PropTypes.func.isRequired,

--- a/src/screens/organizer/organization/page/organizationPage.jsx
+++ b/src/screens/organizer/organization/page/organizationPage.jsx
@@ -9,6 +9,7 @@ import IconLabel from 'components/iconLabel'
 import Button from 'components/button'
 import HasRole from 'screens/components/hasRole'
 import { fetchUsersList } from 'firebase/user'
+import { ROLES } from 'firebase/constants'
 
 import AddMember from './addMember'
 import MemberRow from './memberRow'
@@ -23,11 +24,11 @@ const OrganizationPage = ({ id: organizationId, name, members, addMember, authUs
     })
   }, [members])
 
-  const isOwner = members[authUserId] === 'owner'
+  const isOwner = members[authUserId] === ROLES.OWNER
   return (
     <div className="organization-page">
       <Titlebar className="organization-header" icon="fa fa-users" title={name}>
-        <HasRole of={['owner']} forOrganizationId={organizationId}>
+        <HasRole of={ROLES.OWNER} forOrganizationId={organizationId}>
           <Button secondary>
             {btn => (
               <Link

--- a/src/screens/organizer/organization/page/organizationPage.jsx
+++ b/src/screens/organizer/organization/page/organizationPage.jsx
@@ -14,14 +14,7 @@ import AddMember from './addMember'
 import MemberRow from './memberRow'
 import './organizationPage.css'
 
-const OrganizationPage = ({
-  id: organizationId,
-  name,
-  members,
-  addMember,
-  removeMember,
-  authUserId,
-}) => {
+const OrganizationPage = ({ id: organizationId, name, members, addMember, authUserId }) => {
   const [users, setUsers] = useState([])
 
   useEffect(() => {
@@ -63,7 +56,6 @@ const OrganizationPage = ({
             user={user}
             role={members[user.uid]}
             authUserId={authUserId}
-            removeMember={() => removeMember(user.uid)}
             isOwner={isOwner}
           />
         )}
@@ -78,7 +70,6 @@ OrganizationPage.propTypes = {
   members: PropTypes.objectOf(PropTypes.string),
   authUserId: PropTypes.string.isRequired,
   addMember: PropTypes.func.isRequired,
-  removeMember: PropTypes.func.isRequired,
 }
 
 OrganizationPage.defaultProps = {

--- a/src/screens/organizer/organization/page/removeMember/index.js
+++ b/src/screens/organizer/organization/page/removeMember/index.js
@@ -1,1 +1,1 @@
-export { default } from './removeMember'
+export { default } from './removeMember.container'

--- a/src/screens/organizer/organization/page/removeMember/index.js
+++ b/src/screens/organizer/organization/page/removeMember/index.js
@@ -1,0 +1,1 @@
+export { default } from './removeMember'

--- a/src/screens/organizer/organization/page/removeMember/removeMember.container.js
+++ b/src/screens/organizer/organization/page/removeMember/removeMember.container.js
@@ -1,0 +1,22 @@
+import { inject } from '@k-ramel/react'
+
+import RemoveMember from './removeMember'
+
+const mapStore = (store, { user, organizationId }) => {
+  return {
+    onLeaveMember: () => {
+      store.dispatch({
+        type: '@@ui/REMOVE_ORGANIZATION_MEMBER',
+        payload: { uid: user.uid, organizationId, leave: true },
+      })
+    },
+    onRemoveMember: () => {
+      store.dispatch({
+        type: '@@ui/REMOVE_ORGANIZATION_MEMBER',
+        payload: { uid: user.uid, organizationId },
+      })
+    },
+  }
+}
+
+export default inject(mapStore)(RemoveMember)

--- a/src/screens/organizer/organization/page/removeMember/removeMember.jsx
+++ b/src/screens/organizer/organization/page/removeMember/removeMember.jsx
@@ -1,0 +1,51 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+
+import IconLabel from 'components/iconLabel'
+import Button from 'components/button'
+import { ConfirmationPopin } from 'components/portals'
+
+const RemoveMemberButton = ({ uid, displayName, isOwner, removeMember, authUserId }) => {
+  const canRemove = isOwner && authUserId !== uid
+  const canLeave = !isOwner && authUserId === uid
+
+  return (
+    <ConfirmationPopin
+      title={canRemove ? 'Remove a member' : 'Leave organization'}
+      content={`Are you sure you want to ${
+        canRemove ? `remove ${displayName} from` : 'leave'
+      } organization ?`}
+      className="remove-member-modal"
+      onOk={removeMember}
+      withCancel
+      renderTrigger={({ show }) => (
+        <>
+          {canRemove && (
+            <Button onClick={show} tertiary>
+              <IconLabel icon="fa fa-trash" label="Remove" />
+            </Button>
+          )}
+          {canLeave && (
+            <Button onClick={show} tertiary>
+              <IconLabel icon="fa fa-sign-out" label="Leave" />
+            </Button>
+          )}
+        </>
+      )}
+    />
+  )
+}
+
+RemoveMemberButton.propTypes = {
+  uid: PropTypes.string.isRequired,
+  displayName: PropTypes.string,
+  isOwner: PropTypes.bool.isRequired,
+  removeMember: PropTypes.func.isRequired,
+  authUserId: PropTypes.string.isRequired,
+}
+
+RemoveMemberButton.defaultProps = {
+  displayName: undefined,
+}
+
+export default RemoveMemberButton

--- a/src/screens/organizer/organization/page/removeMember/removeMember.jsx
+++ b/src/screens/organizer/organization/page/removeMember/removeMember.jsx
@@ -4,9 +4,18 @@ import PropTypes from 'prop-types'
 import IconLabel from 'components/iconLabel'
 import Button from 'components/button'
 import { ConfirmationPopin } from 'components/portals'
+import useLeaveOrganization from './useLeaveOrganization'
 
-const RemoveMemberButton = ({ user, isOwner, removeMember, authUserId }) => {
+const RemoveMemberButton = ({
+  organizationId,
+  user,
+  isOwner,
+  onRemoveMember,
+  onLeaveMember,
+  authUserId,
+}) => {
   const { uid, displayName } = user
+  const { leave } = useLeaveOrganization(organizationId, onLeaveMember)
   const canRemove = isOwner && authUserId !== uid
   const canLeave = !isOwner && authUserId === uid
 
@@ -17,7 +26,7 @@ const RemoveMemberButton = ({ user, isOwner, removeMember, authUserId }) => {
         canRemove ? `remove ${displayName} from` : 'leave'
       } organization ?`}
       className="remove-member-modal"
-      onOk={removeMember}
+      onOk={canRemove ? onRemoveMember : leave}
       withCancel
       renderTrigger={({ show }) => (
         <>
@@ -38,9 +47,11 @@ const RemoveMemberButton = ({ user, isOwner, removeMember, authUserId }) => {
 }
 
 RemoveMemberButton.propTypes = {
+  organizationId: PropTypes.string.isRequired,
   user: PropTypes.object.isRequired,
   isOwner: PropTypes.bool.isRequired,
-  removeMember: PropTypes.func.isRequired,
+  onRemoveMember: PropTypes.func.isRequired,
+  onLeaveMember: PropTypes.func.isRequired,
   authUserId: PropTypes.string.isRequired,
 }
 

--- a/src/screens/organizer/organization/page/removeMember/removeMember.jsx
+++ b/src/screens/organizer/organization/page/removeMember/removeMember.jsx
@@ -5,7 +5,8 @@ import IconLabel from 'components/iconLabel'
 import Button from 'components/button'
 import { ConfirmationPopin } from 'components/portals'
 
-const RemoveMemberButton = ({ uid, displayName, isOwner, removeMember, authUserId }) => {
+const RemoveMemberButton = ({ user, isOwner, removeMember, authUserId }) => {
+  const { uid, displayName } = user
   const canRemove = isOwner && authUserId !== uid
   const canLeave = !isOwner && authUserId === uid
 
@@ -37,15 +38,10 @@ const RemoveMemberButton = ({ uid, displayName, isOwner, removeMember, authUserI
 }
 
 RemoveMemberButton.propTypes = {
-  uid: PropTypes.string.isRequired,
-  displayName: PropTypes.string,
+  user: PropTypes.object.isRequired,
   isOwner: PropTypes.bool.isRequired,
   removeMember: PropTypes.func.isRequired,
   authUserId: PropTypes.string.isRequired,
-}
-
-RemoveMemberButton.defaultProps = {
-  displayName: undefined,
 }
 
 export default RemoveMemberButton

--- a/src/screens/organizer/organization/page/removeMember/useLeaveOrganization.js
+++ b/src/screens/organizer/organization/page/removeMember/useLeaveOrganization.js
@@ -1,0 +1,12 @@
+import { useCallback } from 'react'
+import firebase from 'firebase/app'
+
+export default (organizationId, onLeaveMember) => {
+  const leave = useCallback(async () => {
+    const leaveOrganization = firebase.functions().httpsCallable('leaveOrganization')
+    await leaveOrganization({ organizationId })
+    onLeaveMember()
+  }, [organizationId, onLeaveMember])
+
+  return { leave }
+}

--- a/src/screens/organizer/organization/page/removeMember/useLeaveOrganization.js
+++ b/src/screens/organizer/organization/page/removeMember/useLeaveOrganization.js
@@ -4,7 +4,7 @@ import firebase from 'firebase/app'
 export default (organizationId, onLeaveMember) => {
   const leave = useCallback(async () => {
     const leaveOrganization = firebase.functions().httpsCallable('leaveOrganization')
-    await leaveOrganization({ organizationId })
+    leaveOrganization({ organizationId })
     onLeaveMember()
   }, [organizationId, onLeaveMember])
 

--- a/src/screens/organizer/proposal/actions/actions.jsx
+++ b/src/screens/organizer/proposal/actions/actions.jsx
@@ -2,6 +2,7 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import cn from 'classnames'
 
+import HasRole from 'screens/components/hasRole'
 import Titlebar from 'components/titlebar'
 
 import TeamRatings from './teamRatings'
@@ -12,13 +13,15 @@ import styles from './actions.module.css'
 
 const Actions = ({ eventId, proposal, surveyActive, displayOrganizersRatings, className }) => (
   <Titlebar className={cn(styles.header, className)} title={proposal.title}>
-    <EditProposal eventId={eventId} proposal={proposal} />
+    <HasRole of={['owner', 'member']} forEventId={eventId}>
+      <EditProposal eventId={eventId} proposal={proposal} />
 
-    {displayOrganizersRatings && <TeamRatings proposalId={proposal.id} />}
+      {displayOrganizersRatings && <TeamRatings proposalId={proposal.id} />}
 
-    {surveyActive && <SpeakerSurveys eventId={eventId} proposalId={proposal.id} />}
+      {surveyActive && <SpeakerSurveys eventId={eventId} proposalId={proposal.id} />}
 
-    <OrganizersThread eventId={eventId} proposalId={proposal.id} />
+      <OrganizersThread eventId={eventId} proposalId={proposal.id} />
+    </HasRole>
   </Titlebar>
 )
 

--- a/src/screens/organizer/proposal/actions/actions.jsx
+++ b/src/screens/organizer/proposal/actions/actions.jsx
@@ -4,6 +4,7 @@ import cn from 'classnames'
 
 import HasRole from 'screens/components/hasRole'
 import Titlebar from 'components/titlebar'
+import { ROLE_OWNER_OR_MEMBER } from 'firebase/constants'
 
 import TeamRatings from './teamRatings'
 import SpeakerSurveys from './speakerSurveys'
@@ -13,7 +14,7 @@ import styles from './actions.module.css'
 
 const Actions = ({ eventId, proposal, surveyActive, displayOrganizersRatings, className }) => (
   <Titlebar className={cn(styles.header, className)} title={proposal.title}>
-    <HasRole of={['owner', 'member']} forEventId={eventId}>
+    <HasRole of={ROLE_OWNER_OR_MEMBER} forEventId={eventId}>
       <EditProposal eventId={eventId} proposal={proposal} />
 
       {displayOrganizersRatings && <TeamRatings proposalId={proposal.id} />}

--- a/src/screens/organizer/proposals/proposals.jsx
+++ b/src/screens/organizer/proposals/proposals.jsx
@@ -1,6 +1,8 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 
+import HasRole from 'screens/components/hasRole'
+
 import ProposalsHeader from './proposalsHeader'
 import ProposalsFilters from './proposalsFilters'
 import ProposalsToolbar from './proposalsToolbar'
@@ -11,7 +13,9 @@ const Proposals = ({ eventId }) => (
   <div>
     <ProposalsHeader eventId={eventId} />
     <ProposalsFilters />
-    <ProposalsToolbar eventId={eventId} />
+    <HasRole of={['owner', 'member']} forEventId={eventId}>
+      <ProposalsToolbar eventId={eventId} />
+    </HasRole>
     <ProposalsList eventId={eventId} />
     <ProposalsPaging />
   </div>

--- a/src/screens/organizer/proposals/proposals.jsx
+++ b/src/screens/organizer/proposals/proposals.jsx
@@ -2,6 +2,7 @@ import React from 'react'
 import PropTypes from 'prop-types'
 
 import HasRole from 'screens/components/hasRole'
+import { ROLE_OWNER_OR_MEMBER } from 'firebase/constants'
 
 import ProposalsHeader from './proposalsHeader'
 import ProposalsFilters from './proposalsFilters'
@@ -13,7 +14,7 @@ const Proposals = ({ eventId }) => (
   <div>
     <ProposalsHeader eventId={eventId} />
     <ProposalsFilters />
-    <HasRole of={['owner', 'member']} forEventId={eventId}>
+    <HasRole of={ROLE_OWNER_OR_MEMBER} forEventId={eventId}>
       <ProposalsToolbar eventId={eventId} />
     </HasRole>
     <ProposalsList eventId={eventId} />

--- a/src/screens/organizer/proposals/proposalsFilters/proposalsFilters.container.js
+++ b/src/screens/organizer/proposals/proposalsFilters/proposalsFilters.container.js
@@ -13,6 +13,7 @@ const mapStore = (store, props, { router }) => {
   const filters = store.ui.organizer.proposals.get()
 
   return {
+    eventId,
     statuses,
     ratings,
     formats,

--- a/src/screens/organizer/proposals/proposalsFilters/proposalsFilters.jsx
+++ b/src/screens/organizer/proposals/proposalsFilters/proposalsFilters.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types'
 import cn from 'classnames'
 import debounce from 'lodash/debounce'
 
+import HasRole from 'screens/components/hasRole'
 import styles from './proposalsFilters.module.css'
 
 const sortOrderLabel = sortOrder =>
@@ -41,6 +42,7 @@ class ProposalFilters extends Component {
 
   render() {
     const {
+      eventId,
       statuses,
       ratings,
       formats,
@@ -62,14 +64,16 @@ class ProposalFilters extends Component {
         />
 
         {deliberationActive && (
-          <select id="state" onChange={onChange} defaultValue={filters.state}>
-            <option value="">All statuses</option>
-            {statuses.map(status => (
-              <option key={status} value={status}>
-                {statusLabel(status)}
-              </option>
-            ))}
-          </select>
+          <HasRole of={['owner', 'member']} forEventId={eventId}>
+            <select id="state" onChange={onChange} defaultValue={filters.state}>
+              <option value="">All statuses</option>
+              {statuses.map(status => (
+                <option key={status} value={status}>
+                  {statusLabel(status)}
+                </option>
+              ))}
+            </select>
+          </HasRole>
         )}
 
         <select id="ratings" onChange={onChange} defaultValue={filters.ratings}>
@@ -113,6 +117,7 @@ class ProposalFilters extends Component {
 }
 
 ProposalFilters.propTypes = {
+  eventId: PropTypes.string.isRequired,
   statuses: PropTypes.arrayOf(PropTypes.string),
   ratings: PropTypes.arrayOf(PropTypes.string),
   formats: PropTypes.arrayOf(PropTypes.object),

--- a/src/screens/organizer/proposals/proposalsFilters/proposalsFilters.jsx
+++ b/src/screens/organizer/proposals/proposalsFilters/proposalsFilters.jsx
@@ -4,6 +4,8 @@ import cn from 'classnames'
 import debounce from 'lodash/debounce'
 
 import HasRole from 'screens/components/hasRole'
+import { ROLE_OWNER_OR_MEMBER } from 'firebase/constants'
+
 import styles from './proposalsFilters.module.css'
 
 const sortOrderLabel = sortOrder =>
@@ -64,7 +66,7 @@ class ProposalFilters extends Component {
         />
 
         {deliberationActive && (
-          <HasRole of={['owner', 'member']} forEventId={eventId}>
+          <HasRole of={ROLE_OWNER_OR_MEMBER} forEventId={eventId}>
             <select id="state" onChange={onChange} defaultValue={filters.state}>
               <option value="">All statuses</option>
               {statuses.map(status => (

--- a/src/screens/organizer/proposals/proposalsList/proposalSubtitle/proposalSubtitle.container.js
+++ b/src/screens/organizer/proposals/proposalsList/proposalSubtitle/proposalSubtitle.container.js
@@ -3,15 +3,14 @@ import { inject } from '@k-ramel/react'
 import { getFormat, getCategory } from 'store/reducers/data/events.selector'
 import ProposalSubtitle from './proposalSubtitle'
 
-const mapStore = (store, { eventId, proposal }) => {
+const mapStore = (store, { eventId, proposal, blindRating }) => {
   const { formats, categories } = proposal
   const category = getCategory(eventId, categories)(store) || {}
   const format = getFormat(eventId, formats)(store) || {}
-  const { speakerName } = proposal
   return {
     categoryLabel: category.name,
     formatLabel: format.name,
-    speakerName,
+    speakerName: blindRating ? '' : proposal.speakerName,
   }
 }
 

--- a/src/screens/organizer/proposals/proposalsList/proposalsList.container.js
+++ b/src/screens/organizer/proposals/proposalsList/proposalsList.container.js
@@ -21,6 +21,7 @@ const mapStore = (store, { eventId }) => {
     proposals,
     proposalsSelection: items,
     deliberationActive: get(settings, 'deliberation.enabled'),
+    blindRating: get(settings, 'deliberation.blindRating'),
     load: () => store.dispatch('@@ui/ON_LOAD_EVENT_PROPOSALS'),
     onSelect: proposalId => {
       store.dispatch({ type: '@@ui/ON_SELECT_PROPOSAL', payload: { eventId, proposalId } })

--- a/src/screens/organizer/proposals/proposalsList/proposalsList.jsx
+++ b/src/screens/organizer/proposals/proposalsList/proposalsList.jsx
@@ -12,6 +12,7 @@ const Proposals = ({
   proposals,
   proposalsSelection,
   deliberationActive,
+  blindRating,
   onSelect,
   onAddProposalToSelection,
   isMobile,
@@ -23,7 +24,11 @@ const Proposals = ({
       <ListItem
         key={proposal.id}
         title={proposal.title}
-        subtitle={!isMobile && <ProposalSubtitle eventId={eventId} proposal={proposal} />}
+        subtitle={
+          !isMobile && (
+            <ProposalSubtitle eventId={eventId} proposal={proposal} blindRating={blindRating} />
+          )
+        }
         info={<ProposalInfo proposal={proposal} isMobile={isMobile} />}
         onSelect={() => onSelect(proposal.id)}
         onCheckboxChange={() => onAddProposalToSelection(proposal.id)}
@@ -39,6 +44,7 @@ Proposals.propTypes = {
   proposals: PropTypes.arrayOf(PropTypes.object),
   proposalsSelection: PropTypes.arrayOf(PropTypes.string),
   deliberationActive: PropTypes.bool,
+  blindRating: PropTypes.bool,
   onSelect: PropTypes.func.isRequired,
   onAddProposalToSelection: PropTypes.func.isRequired,
   isMobile: PropTypes.bool.isRequired,
@@ -48,6 +54,7 @@ Proposals.defaultProps = {
   proposals: [],
   proposalsSelection: [],
   deliberationActive: false,
+  blindRating: false,
 }
 
 export default withSizes(Proposals)

--- a/src/screens/organizer/sidebar/event/eventSidebar.jsx
+++ b/src/screens/organizer/sidebar/event/eventSidebar.jsx
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types'
 import { SideBarPanel, SideBarLink } from 'layout/sidebar'
 import IconLabel from 'components/iconLabel'
 import HasRole from 'screens/components/hasRole'
+import { ROLE_OWNER_OR_MEMBER } from 'firebase/constants'
 
 const EventSidebar = ({ eventId, name }) => {
   if (!eventId) return null
@@ -12,7 +13,7 @@ const EventSidebar = ({ eventId, name }) => {
       <SideBarLink code="organizer-event-page" eventId={eventId}>
         <IconLabel icon="fa fa-calendar-check-o" label="Event profile" />
       </SideBarLink>
-      <HasRole of={['owner', 'member']} forEventId={eventId}>
+      <HasRole of={ROLE_OWNER_OR_MEMBER} forEventId={eventId}>
         <SideBarLink code="organizer-event-edit" eventId={eventId}>
           <IconLabel icon="fa fa-gear" label="Configuration" />
         </SideBarLink>

--- a/src/screens/organizer/sidebar/event/eventSidebar.jsx
+++ b/src/screens/organizer/sidebar/event/eventSidebar.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types'
 
 import { SideBarPanel, SideBarLink } from 'layout/sidebar'
 import IconLabel from 'components/iconLabel'
+import HasRole from 'screens/components/hasRole'
 
 const EventSidebar = ({ eventId, name }) => {
   if (!eventId) return null
@@ -11,9 +12,11 @@ const EventSidebar = ({ eventId, name }) => {
       <SideBarLink code="organizer-event-page" eventId={eventId}>
         <IconLabel icon="fa fa-calendar-check-o" label="Event profile" />
       </SideBarLink>
-      <SideBarLink code="organizer-event-edit" eventId={eventId}>
-        <IconLabel icon="fa fa-gear" label="Configuration" />
-      </SideBarLink>
+      <HasRole of={['owner', 'member']} forEventId={eventId}>
+        <SideBarLink code="organizer-event-edit" eventId={eventId}>
+          <IconLabel icon="fa fa-gear" label="Configuration" />
+        </SideBarLink>
+      </HasRole>
       <SideBarLink code="organizer-event-proposals" eventId={eventId}>
         <IconLabel icon="fa fa-paper-plane" label="Proposals" />
       </SideBarLink>

--- a/src/store/listeners.js
+++ b/src/store/listeners.js
@@ -59,7 +59,8 @@ export default [
   when('@@ui/ON_LOAD_USER_ORGANIZATIONS')(organizations.ofUser),
   when('@@ui/ON_CREATE_ORGANIZATION')(organizations.create),
   when('@@ui/ON_UPDATE_ORGANIZATION')(organizations.update),
-  when('@@ui/ADD_ORGANIZATION_MEMBER')(organizations.addMember),
+  when('@@ui/ADD_ORGANIZATION_MEMBER')(organizations.setMember),
+  when('@@ui/CHANGE_ORGANIZATION_MEMBER_ROLE')(organizations.setMember),
   when('@@ui/REMOVE_ORGANIZATION_MEMBER')(organizations.removeMember),
   /* submissions */
   when('@@ui/GO_TO_EVENT_SUBMISSION')(submissions.openEventSubmission),

--- a/src/store/reactions/app.js
+++ b/src/store/reactions/app.js
@@ -1,11 +1,9 @@
 /* eslint-disable import/prefer-default-export */
 
-export const init = (action, store, { router }) => {
-  const isOrganizer = router.getParam('root') === 'organizer'
-
+export const init = (action, store) => {
   // get eventId from app event context
   const currentEventId = localStorage.getItem('currentEventId')
-  if (!isOrganizer && currentEventId) {
+  if (currentEventId) {
     store.ui.app.update({ currentEventId })
     store.dispatch({ type: '@@ui/ON_LOAD_EVENT', payload: currentEventId })
   }

--- a/src/store/reactions/auth.js
+++ b/src/store/reactions/auth.js
@@ -61,7 +61,7 @@ export const signedIn = async (action, store) => {
 
   // get users organizations
   const organizations = await fetchUserOrganizations(user.uid)
-  store.data.organizations.set(organizations.docs.map(ref => ({ id: ref.id, ...ref.data() })))
+  store.data.organizations.set(organizations)
 
   // go to the redirect url if exists
   store.dispatch('@@router/REDIRECT_TO_NEXT_URL')

--- a/src/store/reactions/organizations.js
+++ b/src/store/reactions/organizations.js
@@ -1,11 +1,12 @@
 import { flow, set, unset } from 'immutadot'
 
-import organizationCrud, { fetchUserOrganizations, ROLES } from 'firebase/organizations'
+import organizationCrud, { fetchUserOrganizations } from 'firebase/organizations'
+import { ROLES } from 'firebase/constants'
 
 export const create = async (action, store, { router }) => {
   const data = action.payload
   const { uid } = store.auth.get()
-  const newUserOrganization = flow(set(`members.${uid}`, ROLES.OWNER), set('owner', uid))(data)
+  const newUserOrganization = flow(set(`members.${uid}`, ROLES.OWNER), set(ROLES.OWNER, uid))(data)
 
   store.ui.loaders.update({ isOrganizationSaving: true })
   const ref = await organizationCrud.create(newUserOrganization)

--- a/src/store/reactions/organizations.js
+++ b/src/store/reactions/organizations.js
@@ -45,7 +45,7 @@ export const ofUser = async (action, store) => {
 export const addMember = async (action, store, { router }) => {
   const { uid, organizationId } = action.payload
   const organization = store.data.organizations.get(organizationId)
-  const updated = set(organization, `members.${uid}`, ROLES.MEMBER)
+  const updated = set(organization, `members.${uid}`, ROLES.REVIEWER)
   await organizationCrud.update(updated)
   store.data.organizations.update(updated)
   router.push('organizer-organization-page', { organizationId })

--- a/src/store/reactions/organizations.js
+++ b/src/store/reactions/organizations.js
@@ -42,10 +42,10 @@ export const ofUser = async (action, store) => {
   store.data.organizations.set(organizations)
 }
 
-export const addMember = async (action, store, { router }) => {
-  const { uid, organizationId } = action.payload
+export const setMember = async (action, store, { router }) => {
+  const { uid, organizationId, role } = action.payload
   const organization = store.data.organizations.get(organizationId)
-  const updated = set(organization, `members.${uid}`, ROLES.REVIEWER)
+  const updated = set(organization, `members.${uid}`, role || ROLES.REVIEWER)
   await organizationCrud.update(updated)
   store.data.organizations.update(updated)
   router.push('organizer-organization-page', { organizationId })

--- a/src/store/reactions/organizations.js
+++ b/src/store/reactions/organizations.js
@@ -52,10 +52,16 @@ export const setMember = async (action, store, { router }) => {
 }
 
 export const removeMember = async (action, store, { router }) => {
-  const { uid, organizationId } = action.payload
+  const { uid, organizationId, leave } = action.payload
   const organization = store.data.organizations.get(organizationId)
   const updated = unset(organization, `members.${uid}`)
-  await organizationCrud.update(updated)
+  if (!leave) {
+    await organizationCrud.update(updated)
+  }
   store.data.organizations.update(updated)
-  router.push('organizer-organization-page', { organizationId })
+  if (leave) {
+    router.push('organizer-organizations')
+  } else {
+    router.push('organizer-organization-page', { organizationId })
+  }
 }

--- a/src/store/reactions/organizations.js
+++ b/src/store/reactions/organizations.js
@@ -1,11 +1,11 @@
 import { flow, set, unset } from 'immutadot'
 
-import organizationCrud, { fetchUserOrganizations } from 'firebase/organizations'
+import organizationCrud, { fetchUserOrganizations, ROLES } from 'firebase/organizations'
 
 export const create = async (action, store, { router }) => {
   const data = action.payload
   const { uid } = store.auth.get()
-  const newUserOrganization = flow(set(`members.${uid}`, true), set('owner', uid))(data)
+  const newUserOrganization = flow(set(`members.${uid}`, ROLES.OWNER), set('owner', uid))(data)
 
   store.ui.loaders.update({ isOrganizationSaving: true })
   const ref = await organizationCrud.create(newUserOrganization)
@@ -39,13 +39,13 @@ export const get = async (action, store, { router }) => {
 export const ofUser = async (action, store) => {
   const { uid } = store.auth.get()
   const organizations = await fetchUserOrganizations(uid)
-  store.data.organizations.set(organizations.docs.map(ref => ({ id: ref.id, ...ref.data() })))
+  store.data.organizations.set(organizations)
 }
 
 export const addMember = async (action, store, { router }) => {
   const { uid, organizationId } = action.payload
   const organization = store.data.organizations.get(organizationId)
-  const updated = set(organization, `members.${uid}`, true)
+  const updated = set(organization, `members.${uid}`, ROLES.MEMBER)
   await organizationCrud.update(updated)
   store.data.organizations.update(updated)
   router.push('organizer-organization-page', { organizationId })


### PR DESCRIPTION
In an organization, be able to have different roles:
- owner: by default, the creator of the organization
- member: can manage organization events
- reviewer: can only access to proposals list and some features in it.

### Permissions by roles

**Owner:** 
- Can manage organization
- Has all events permissions
- Has all proposals permissions

**Member:** 
- Can only leave the organization
- Has all events permissions
- Has all proposals permissions

**Reviewer:**
- Can only leave the organization.
- Has access to event's proposals and can only vote

### Technical tasks
- [x] Use [role firestore model](https://firebase.google.com/docs/firestore/solutions/role-based-access)
- [x] Add Firestore rules tests for organization
- [x] Add Firestore rules tests for events, proposals, ratings...
- [x] Adapt organization components to the new roles
- [x] Manage role adding or updating a member
- [x] Manage role inviting a member
- [x] Restrict actions to the user role
- [x] Sort member by names (in organization page)
- [x] Use a cloud function to "leave" an organization and test it
- [x] Refactor, clean and test code (member list, custom hooks...)
- [x] Make a migration to the new model (all organizers will be member by default) except the owner


Closes #368
Closes #669