### PR TITLE
:bug: Fix big images breaking review proposal layout

### DIFF
--- a/src/screens/organizer/proposal/proposal.css
+++ b/src/screens/organizer/proposal/proposal.css
@@ -28,6 +28,10 @@
   grid-area: proposal-talk / proposal-talk / proposal-speakers / proposal-speakers;
 }
 
+.proposal-talk img {
+  max-width: 100%;
+}
+
 .proposal-speakers {
   grid-area: proposal-speakers;
 }


### PR DESCRIPTION
If a speaker post an abstract containing a big image it breaks the proposal review layout.