### PR TITLE
Change rectangles size on the homepage, fixing #759

### DIFF
--- a/src/screens/conference/home/home.css
+++ b/src/screens/conference/home/home.css
@@ -49,5 +49,7 @@
 
   .home .home-link {
     font-size: 0.9em;
+    min-height: 18em;
+    min-width: 18em;
   }
 }


### PR DESCRIPTION
Fix #759 

Now looks like the following:

<img width="411" alt="Screenshot 2020-10-01 at 08 49 53" src="https://user-images.githubusercontent.com/752030/94777177-4f5e0580-03c3-11eb-9359-82ef0309af1d.png">
