### PR TITLE
💬 highlight required action in accepted talk email

### DIFF
--- a/functions/triggers/onUpdateProposal.js
+++ b/functions/triggers/onUpdateProposal.js
@@ -64,6 +64,10 @@ module.exports = functions.firestore
 
       const status = proposal.state === 'accepted' ? 'accepted' : 'declined'
       const { cc, bcc } = await getEmailRecipients(event, settings, proposal.state)
+      const subject =
+        status === 'accepted'
+          ? `[${event.name}] [Action required] Talk ${status}! Please confirm your presence`
+          : `[${event.name}] Talk ${status}`
 
       return Promise.all([
         getUsers(uids),
@@ -74,7 +78,7 @@ module.exports = functions.firestore
         cc,
         bcc,
         contact: event.contact,
-        subject: `[${event.name}] Talk ${status}`,
+        subject,
         html: status === 'accepted' ? talkAccepted(event, users, proposal, app) : talkRejected(event, users, proposal, app),
         confName: event.name,
         webHookInfo: { type: 'deliberation_email', talkId: proposal.id, eventId },

--- a/functions/triggers/onUpdateProposal.test.js
+++ b/functions/triggers/onUpdateProposal.test.js
@@ -123,7 +123,7 @@ describe('onUpdateProposal', () => {
       key: 'SOME-SECRET',
     }), sinon.match({
       to: ['corinnekrych@gmail.com'],
-      subject: '[RivieraDEV 2019] Talk accepted',
+      subject: '[RivieraDEV 2019] [Action required] Talk accepted! Please confirm your presence',
       html: sinon.match.any,
       confName: 'RivieraDEV 2019',
     }))


### PR DESCRIPTION
Hi! 👋

Speakers (myself included!) often don't realize that they need to open this email and confirm their presence via the link. This changes the email subject to highlight this. What do you think?

Since this is a very small change, and the contribution guide does not require me to, I opted not to open an issue first.

Thank you for maintaining Conference Hall! 💙