### PR TITLE
✨ Allow GET verb to accept or reject a proposal

### DIFF
--- a/docs/apis/proposals.story.mdx
+++ b/docs/apis/proposals.story.mdx
@@ -11,6 +11,7 @@ As organizer, you can generate an API key for an event in Conference Hall throug
 ### Endpoint
 
 `PUT /api/v1/proposal/{event_id}/{proposal_id}/accept`
+`GET /api/v1/proposal/{event_id}/{proposal_id}/accept`
 
 ### Parameters
 
@@ -31,6 +32,7 @@ As organizer, you can generate an API key for an event in Conference Hall throug
 ### Endpoint
 
 `PUT /api/v1/proposal/{event_id}/{proposal_id}/reject`
+`GET /api/v1/proposal/{event_id}/{proposal_id}/reject`
 
 ### Parameters
 

--- a/functions/api/v1/index.js
+++ b/functions/api/v1/index.js
@@ -13,5 +13,7 @@ router.get('/event/:eventId', withApiKey, getEvent)
 // Proposal deliberation API
 router.put('/proposal/:eventId/:proposalId/accept', withApiKey, acceptProposal)
 router.put('/proposal/:eventId/:proposalId/reject', withApiKey, rejectProposal)
+router.get('/proposal/:eventId/:proposalId/accept', withApiKey, acceptProposal)
+router.get('/proposal/:eventId/:proposalId/reject', withApiKey, rejectProposal)
 
 module.exports = router


### PR DESCRIPTION
@brunosabot previously added PUT endpoints to accept or reject a proposal (see PR #687).

Unfortunately at the time I missed the fact that we're using Trello cards to do our deliberation.
On each Trello card (a proposal) we add links to accept or reject the proposal. As the call is done from the browser it is a GET request, so we cannot use the endpoints as they are.

This PR only adds the same endpoints with the verb GET, allowing them to be called directly from a browser.

If there is another simpler solution I'm all ears.