### PR TITLE
🐛 Fix proposal URL in Slack and emails

### DIFF
--- a/functions/email/templates/talkReceived.js
+++ b/functions/email/templates/talkReceived.js
@@ -10,7 +10,7 @@ module.exports = (event, talk, app) => `
 <body>
   <p>✨ The talk <strong>"${talk.title}"</strong> has been submitted to <strong>${event.name}</strong></p>
   <p>
-  <strong><a href="${app.url}/organizer/event/${event.id}/proposal/${talk.id}">Check it now!</a></strong>
+  <strong><a href="${app.url}/organizer/event/${event.id}/proposals/${talk.id}">Check it now!</a></strong>
   </p>
   <p>
   Made with 💗 by <a href="${app.url}">conference-hall.io</a> – <i>"${event.name}" team</i>

--- a/functions/slack/index.js
+++ b/functions/slack/index.js
@@ -15,7 +15,7 @@ const buildMessage = (event, talk, speakers, app) => {
     author_name: `by ${speakers.map(s => s.displayName).join(' & ')}`,
     title: talk.title,
     text: talk.abstract,
-    title_link: `${app.url}/organizer/event/${event.id}/proposal/${talk.id}`,
+    title_link: `${app.url}/organizer/event/${event.id}/proposals/${talk.id}`,
     thumb_url: get(first(speakers), 'photoURL'),
     color: '#ffab00',
     fields: [],


### PR DESCRIPTION
Fixes the URL in Slack and email templates, where `/proposal/` should be `/proposals/`.

Found when clicking on a link in the Slack integration and being directed to a blank page 😉 