### PR TITLE
:sparkles: Allow to copy text without button

### DIFF
--- a/src/components/titlebar/titlebar.css
+++ b/src/components/titlebar/titlebar.css
@@ -14,6 +14,7 @@
 .titlebar .titlebar-actions {
   display: flex;
   align-items: center;
+  user-select: none;
 }
 
 .titlebar .titlebar-actions > * {

--- a/src/features/proposal/page/ratings/ratings.css
+++ b/src/features/proposal/page/ratings/ratings.css
@@ -5,6 +5,7 @@
   grid-template-areas: 'btn-previous btn-ratings btn-next';
   grid-gap: 1em;
   align-items: center;
+  user-select: none;
 }
 
 .btn-previous {

--- a/src/features/proposal/selection/talkSelection.module.css
+++ b/src/features/proposal/selection/talkSelection.module.css
@@ -1,5 +1,6 @@
 .wrapper {
   display: flex;
+  user-select: none;
 }
 
 .selector {


### PR DESCRIPTION
When we copy a proposal, there are all button info copied.
This PR allow copying the proposals without any button text.

There a still an issue, there are no space between badge, is it ok to add {' '} between all badge ?